### PR TITLE
Recover Pages threaded runtime after force reload

### DIFF
--- a/DONE.md
+++ b/DONE.md
@@ -8,6 +8,24 @@ Grouped by the same milestones as `PROJECT.md` / `TODO.md`.
 
 ---
 
+## Forced-reload isolation recovery (2026-07-12)
+
+- [x] Reproduced the public report's post-force-reload failure against the
+      live `newshoes.gg` deployment. A Chrome navigation that bypassed the
+      service worker loaded the unisolated bootstrap with an activated
+      isolation-worker registration but no document controller, then failed
+      after 12 seconds with `The updated isolation helper did not take control
+      in time.` Restarting Chrome also cleared the condition, matching the
+      reporter's follow-up.
+- [x] Made the Pages bootstrap verify the registration's active worker
+      directly when a force-reloaded document has no controller, then perform
+      the normal navigation required for that worker to provide COOP/COEP.
+      The deployment smoke now drives the service-worker-bypass path through
+      Chrome DevTools and requires the canonical launcher, cross-origin
+      isolation, `SharedArrayBuffer`, the threaded RPC surface, shared wasm
+      heap, and transferred canvas afterward. The standard deployment smoke
+      and five consecutive pinned-old-worker rollout runs passed locally.
+
 ## Browser text-entry input repair (2026-07-12)
 
 - [x] Restored end-to-end browser text entry by removing the probe-only

--- a/TODO.md
+++ b/TODO.md
@@ -23,6 +23,17 @@ shares structure and follows behind.
       `npm run test:pages-worker-rollout` when changing the Pages bootstrap or
       isolation worker; the production deployment gate continues to prove a
       fresh isolated root boot, reload, pthread heap, and OffscreenCanvas.
+      2026-07-12: forced-reload recovery coverage now passes along with five
+      consecutive local pinned-worker rollouts; constrained shared-CI
+      stability remains the open part of this item.
+- [ ] Reproduce the first `archive mount failed` half of the 2026-07-12 Reddit
+      long-session report independently from its now-reproduced force-reload
+      isolation failure. Capture the visible launch detail or issue dump, and
+      exercise background freeze/discard plus fresh-document relaunch against
+      a persistent installed archive set to distinguish an engine-realm death
+      from OPFS staging or sync-handle contention. Do not infer that cause from
+      the bootstrap failure alone; the reporter confirmed only that restarting
+      Chrome recovered both symptoms.
 
 MERGED to `main` (verified, clean, green build): perf-drawstate (state-skip perf + geometry/texture correctness fixes), zorder-fix (RTT null-FBO depth-pollution fix — 0 FBO failures), audio-ini-fix (non-Default audio INI entries → audio subsystem inits plus base-Generals `Music.big` extraction), live-skirmish-start, mounted MSS stream playback, DXT CPU fallback and DXT1/2/3/4/5 browser draw coverage, draw-order-fix (D3DRS_ZBIAS 24-bit depth-bias scale in bridge.js — commit 33641ab).
 

--- a/WebAssembly/harness/pages_deployment_smoke.mjs
+++ b/WebAssembly/harness/pages_deployment_smoke.mjs
@@ -255,6 +255,27 @@ try {
     if (new URL(rootPage.url()).pathname !== "/") {
       throw new Error(`Reloaded domain-root launcher exposed a noncanonical path: ${rootPage.url()}`);
     }
+
+    // Chrome's force reload bypasses the service worker for one navigation.
+    // The bootstrap page is therefore unisolated and has no controller, even
+    // though the registration still owns an activated isolation worker. The
+    // bootstrap must verify registration.active and navigate once normally;
+    // requiring a controller on the bypassed document strands users on the
+    // "could not start the threaded runtime" screen until Chrome restarts.
+    const devtools = await rootContext.newCDPSession(rootPage);
+    await devtools.send("Network.enable");
+    await devtools.send("Network.setBypassServiceWorker", { bypass: true });
+    await rootPage.reload({ waitUntil: "domcontentloaded" });
+    await devtools.send("Network.setBypassServiceWorker", { bypass: false });
+    await rootPage.waitForURL(rootBaseUrl, { timeout: 30000 });
+    await rootPage.waitForSelector("#desktop", { state: "visible", timeout: 30000 });
+    await rootPage.waitForFunction(() => window.crossOriginIsolated
+      && typeof SharedArrayBuffer === "function"
+      && Boolean(navigator.serviceWorker.controller)
+      && Boolean(window.CnCPort?.rpc), null, { timeout: 30000 });
+    if (new URL(rootPage.url()).pathname !== "/") {
+      throw new Error(`Force-reloaded domain-root launcher exposed a noncanonical path: ${rootPage.url()}`);
+    }
   } finally {
     await rootContext.close();
   }
@@ -419,6 +440,7 @@ try {
     runtime,
     canonicalPath: { first: firstPathname, reload: reloadPathname },
     domainRootCanonical: true,
+    forceReloadRecovery: true,
     workerRollout,
     legacyPlayRecovery: true,
     legalNotice: true,

--- a/WebAssembly/pages/coi-bootstrap.js
+++ b/WebAssembly/pages/coi-bootstrap.js
@@ -69,9 +69,8 @@
     return fallback.href;
   }
 
-  function controlledWorkerVersion() {
-    const controller = navigator.serviceWorker.controller;
-    if (!controller) return Promise.resolve(null);
+  function serviceWorkerVersion(worker) {
+    if (!worker) return Promise.resolve(null);
     return new Promise((resolve) => {
       const channel = new MessageChannel();
       let timer = 0;
@@ -88,17 +87,25 @@
         finish(event.data?.version || null);
       };
       try {
-        controller.postMessage({ type: versionRequest }, [channel.port2]);
+        worker.postMessage({ type: versionRequest }, [channel.port2]);
       } catch {
         finish(null);
       }
     });
   }
 
-  async function waitForCurrentWorker() {
+  async function waitForCurrentWorker(registration) {
     const deadline = Date.now() + 12000;
     while (Date.now() < deadline) {
-      if (await controlledWorkerVersion() === workerVersion) return;
+      const controller = navigator.serviceWorker.controller;
+      if (await serviceWorkerVersion(controller) === workerVersion) return;
+      // A forced reload bypasses the service worker for that navigation, so
+      // this document has no controller even though the registration still
+      // has a healthy active worker. Verify that worker directly, then let
+      // openTarget() perform the normal navigation that it can control.
+      const active = registration.active;
+      if (active !== controller
+          && await serviceWorkerVersion(active) === workerVersion) return;
       await new Promise((resolve) => setTimeout(resolve, 50));
     }
     throw new Error("The updated isolation helper did not take control in time.");
@@ -110,7 +117,7 @@
       updateViaCache: "none",
     });
     await registration.update();
-    await waitForCurrentWorker();
+    await waitForCurrentWorker(registration);
   }
 
   function openTarget() {

--- a/WebAssembly/tools/check_pages_sources.mjs
+++ b/WebAssembly/tools/check_pages_sources.mjs
@@ -92,7 +92,9 @@ const bootstrap = await readFile(resolve(wasmRoot, "pages/coi-bootstrap.js"), "u
 for (const contract of [
   'const workerVersion = "project-new-shoes.pages-root.v1"',
   "await installCurrentWorker()",
-  "await waitForCurrentWorker()",
+  "await waitForCurrentWorker(registration)",
+  "const active = registration.active",
+  "await serviceWorkerVersion(active) === workerVersion",
   "if (destination === location.href)",
   "location.reload()",
 ]) {


### PR DESCRIPTION
## What changed

- Teach the GitHub Pages isolation bootstrap to query the registration's active service worker when a force-reloaded document has no controller.
- Keep the existing controller/version check for normal loads and old-worker rollouts.
- Extend the Pages deployment smoke with a Chrome service-worker-bypass reload and require the canonical launcher, cross-origin isolation, `SharedArrayBuffer`, threaded RPC, shared wasm heap, and transferred canvas afterward.
- Record the confirmed fix and retain a separate TODO for the report's earlier `archive mount failed` message, whose detailed cause was not available.

## Root cause

A Chrome force reload bypasses the service worker for that navigation. The network bootstrap page is therefore unisolated and has no `navigator.serviceWorker.controller`, even though its registration still has a healthy activated isolation worker. The bootstrap only queried the missing controller, waited 12 seconds, and failed with:

`Service worker setup failed: The updated isolation helper did not take control in time.`

Restarting Chrome made the next navigation controlled again, matching the reporter's workaround. The bootstrap now verifies `registration.active` directly and performs one normal navigation that the worker can control.

## Validation

- Reproduced the exact public failure against `https://newshoes.gg/` with a persistent Chromium profile and a service-worker-bypassing reload.
- `npm run check:pages`
- `npm run verify:pages-site`
- `npm run test:pages-deployment`
- `npm run test:pages-worker-rollout` — five consecutive passes; each upgraded the pinned `18b95831` worker in two navigations and proved the threaded runtime.
- `npm run verify:save-persistence-order`
- `npm run verify:runtime-shutdown-order`

The first `archive mount failed` message could not be independently attributed without its visible detail/issue dump, so this PR does not claim an unproven OPFS or engine-worker cause.
