### PR TITLE
Refresh README feature status

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,25 +29,31 @@ This public URL points to the current GitHub Pages deployment.
 
 ## Status
 
-This is a playable development build, not a finished release. The current
-threaded runtime:
+Project New Shoes is a playable browser port of Zero Hour. It boots the real
+engine, runs skirmishes against the original AI, renders the game through
+WebGL2, and uses the original UI, input, simulation, and command paths. It is
+still a development build, but the foundational port is working.
 
-- completes the original Zero Hour engine initialization path;
-- renders the shell, menus, terrain, objects, effects, and playable skirmishes
-  through WebGL2;
-- uses translated D3D8 vertex and pixel shaders by default, with the classic
-  fixed-function path still available;
-- routes Miles-style audio calls to Web Audio;
-- imports required data from original media or an existing installation into
-  browser-local OPFS storage;
-- accepts the original mouse and keyboard input paths;
-- has save persistence and a short four-player WebRTC match gate; and
-- can close and relaunch from the browser desktop.
+| Area | Status | Current support |
+|---|---|---|
+| Engine and shell | **Works** | The threaded WebAssembly runtime completes the original Zero Hour initialization path and renders the shell and menus. |
+| Skirmish | **Works** | Playable matches run against the original AI. All official multiplayer maps have been driven to a rendered skirmish state. |
+| Mouse, keyboard, and UI | **Works** | Browser events feed the original input path, including menus, text entry, camera controls, selection, building, production, movement, and common combat commands. |
+| Game-data installation | **Works** | The launcher imports an installed copy or complete original media, validates the required archives, and stores them locally in OPFS. |
+| Launcher lifecycle | **Works** | Display and shader settings, diagnostics, game launch, clean shutdown, save persistence, and relaunch are implemented. |
+| Rendering | **Partially works** | Terrain, objects, UI, particles, effects, and the shipped D3D8 shader model 1.1 programs render through WebGL2. Enhanced and classic tiers work; some shader, animation, terrain, effect, and UI fidelity issues remain. |
+| Audio | **Partially works** | Engine-driven music, speech, streams, and 2D/3D samples play through Web Audio. Natural gameplay coverage and mixing still need polish. |
+| Campaign and Generals Challenge | **Partially works** | The original engine paths are present, but complete mission, challenge, cutscene, and win/loss flows are not yet verified end to end. |
+| Saves and loading | **Partially works** | Browser-local save persistence works. Broader save creation, loading, compatibility, and full-match coverage remain in progress. |
+| Multiplayer | **Partially works** | The original lockstep protocol runs over WebRTC, with short matches verified at up to four players. Long sessions, reconnect/disconnect behavior, determinism coverage, and public signaling hardening remain. |
+| Movies | **Not yet** | Bink metadata and presentation paths have focused coverage, but full retail movie playback and audio sync are not complete. |
+| Browser support | **Chromium only for now** | Desktop Chrome and Chromium are the primary tested targets. Firefox and Safari are not yet release targets. |
+| Vanilla Generals | **Not yet** | Generals data is used by Zero Hour, but the launcher does not currently expose a separate vanilla Generals runtime. |
 
-Fidelity, campaigns, video, natural gameplay audio coverage, long multiplayer
-sessions, save/load coverage, performance, and browser compatibility still need
-work. Chrome and Chromium are the primary tested browsers. Firefox and Safari
-are not yet release targets.
+Performance, memory use, context-loss handling, crash recovery, and fidelity are
+active product work. See [GitHub Issues](https://github.com/Agusx1211/NewShoes/issues)
+for the live backlog; the table above describes current capability rather than
+a promise that every game path is complete.
 
 ## What you need
 

--- a/README.md
+++ b/README.md
@@ -29,39 +29,40 @@ This public URL points to the current GitHub Pages deployment.
 
 ## Status
 
-Project New Shoes is a playable browser port of Zero Hour. It boots the real
-engine, runs skirmishes against the original AI, renders the game through
-WebGL2, and uses the original UI, input, simulation, and command paths. It is
-still a development build, but the foundational port is working.
+Project New Shoes is already the real Zero Hour game running in a browser. It
+boots the original engine, runs skirmishes against the original AI, renders the
+game through WebGL2, and uses the original UI, input, simulation, and command
+paths. This is a playable development build with the major systems in place.
 
 | Area | Status | Current support |
 |---|---|---|
-| Engine and shell | **Works** | The threaded WebAssembly runtime completes the original Zero Hour initialization path and renders the shell and menus. |
-| Skirmish | **Works** | Playable matches run against the original AI. All official multiplayer maps have been driven to a rendered skirmish state. |
-| Mouse, keyboard, and UI | **Works** | Browser events feed the original input path, including menus, text entry, camera controls, selection, building, production, movement, and common combat commands. |
-| Game-data installation | **Works** | The launcher imports an installed copy or complete original media, validates the required archives, and stores them locally in OPFS. |
-| Launcher lifecycle | **Works** | Display and shader settings, diagnostics, game launch, clean shutdown, save persistence, and relaunch are implemented. |
-| Rendering | **Partially works** | Terrain, objects, UI, particles, effects, and the shipped D3D8 shader model 1.1 programs render through WebGL2. Enhanced and classic tiers work; some shader, animation, terrain, effect, and UI fidelity issues remain. |
-| Audio | **Partially works** | Engine-driven music, speech, streams, and 2D/3D samples play through Web Audio. Natural gameplay coverage and mixing still need polish. |
-| Campaign and Generals Challenge | **Partially works** | The original engine paths are present, but complete mission, challenge, cutscene, and win/loss flows are not yet verified end to end. |
-| Saves and loading | **Partially works** | Browser-local save persistence works. Broader save creation, loading, compatibility, and full-match coverage remain in progress. |
-| Multiplayer | **Partially works** | The original lockstep protocol runs over WebRTC, with short matches verified at up to four players. Long sessions, reconnect/disconnect behavior, determinism coverage, and public signaling hardening remain. |
-| Movies | **Not yet** | Bink metadata and presentation paths have focused coverage, but full retail movie playback and audio sync are not complete. |
-| Browser support | **Chromium only for now** | Desktop Chrome and Chromium are the primary tested targets. Firefox and Safari are not yet release targets. |
-| Vanilla Generals | **Not yet** | Generals data is used by Zero Hour, but the launcher does not currently expose a separate vanilla Generals runtime. |
+| Engine and shell | ✅ **Works** | The threaded WebAssembly runtime completes the original Zero Hour initialization path and renders the shell and menus. |
+| Skirmish | ✅ **Works** | Playable matches run against the original AI. All official multiplayer maps have been driven to a rendered skirmish state. |
+| Mouse, keyboard, and UI | ✅ **Works** | Browser events feed the original input path, including menus, text entry, camera controls, selection, building, production, movement, and common combat commands. |
+| Game-data installation | ✅ **Works** | The launcher imports an installed copy or complete original media, validates the required archives, and stores them locally in OPFS. |
+| Launcher lifecycle | ✅ **Works** | Display and shader settings, diagnostics, game launch, clean shutdown, browser-local storage, and relaunch are implemented. |
+| Rendering | ✅ **Works** | Terrain, objects, UI, particles, effects, and the shipped D3D8 shader model 1.1 programs render through WebGL2 in enhanced and classic modes. Remaining fidelity fixes are ongoing polish. |
+| Audio | ✅ **Works well** | Engine-driven music, speech, streams, and 2D/3D samples play through Web Audio. Remaining work is focused on edge-case coverage and mixing polish. |
+| Campaign and Generals Challenge | 🧪 **In testing** | The original campaign and challenge paths run through the real engine. Broader mission, cutscene, and win/loss validation is ongoing. |
+| Saves and loading | 🚧 **Broken** | In-game save and load flows are not currently reliable. Browser storage foundations exist, but saves should not yet be treated as supported. |
+| Multiplayer | 🧪 **Playable, experimental** | The original lockstep protocol runs over WebRTC, with short matches verified at up to four players. Long sessions, reconnect/disconnect behavior, determinism coverage, and public signaling hardening remain. |
+| Movies | ✅ **Implemented** | Bink movie presentation and browser-side playback are implemented in the threaded runtime. Broader format coverage and playback polish are ongoing. |
+| Browser support | ✅ **Works** | Chrome and Chromium receive the most testing. Other modern browsers also work when they provide the required web-platform features, but do not yet receive the same validation. |
+| Vanilla Generals | 🗓️ **Planned** | Generals data is used by Zero Hour, but the launcher does not currently expose a separate vanilla Generals runtime. |
 
-Performance, memory use, context-loss handling, crash recovery, and fidelity are
-active product work. See [GitHub Issues](https://github.com/Agusx1211/NewShoes/issues)
-for the live backlog; the table above describes current capability rather than
-a promise that every game path is complete.
+The big pieces are in place. Current work is focused on fidelity, performance,
+reliability, broader gameplay coverage, and browser validation. See
+[GitHub Issues](https://github.com/Agusx1211/NewShoes/issues) for the live
+backlog.
 
 ## What you need
 
-The runtime currently requires a desktop Chromium browser with WebGL2,
-`SharedArrayBuffer`, cross-origin isolation, and Origin Private File System
-support. Localhost is sufficient for development. A LAN or hosted deployment
-must use HTTPS and send the required COOP/COEP headers; see the
-[deployment guide](WebAssembly/DEPLOYMENT.md).
+The runtime requires a modern desktop browser with WebGL2, `SharedArrayBuffer`,
+cross-origin isolation, and Origin Private File System support. Chrome and
+Chromium are the primary tested targets; other capable browsers also work
+without the same level of validation. Localhost is sufficient for development.
+A LAN or hosted deployment must use HTTPS and send the required COOP/COEP
+headers; see the [deployment guide](WebAssembly/DEPLOYMENT.md).
 
 You also need both Generals and Zero Hour retail data. The launcher supports two
 ownership paths:


### PR DESCRIPTION
## What changed

- Reframe the project status around the playable browser port that exists today.
- Add an emoji support matrix for engine startup, skirmish, input, installation, lifecycle, rendering, audio, campaigns, saves, multiplayer, movies, browsers, and vanilla Generals.
- Mark the major working systems positively, distinguish experimental/testing areas, and call out broken save/load support directly.
- Clarify that Chrome and Chromium receive the most testing without implying they are the only browsers that work.

## Why

The previous prose-only summary understated the working engine and made the remaining limitations harder to scan. The new matrix gives players and contributors a more accurate and confident picture of the current product.

## Impact

README visitors can quickly see that the real engine, skirmish, original AI, rendering, audio, movies, input, asset installation, and lifecycle work today. Experimental areas and the currently broken save/load flow remain clearly identified.

## Validation

- `git diff --check`
- Verified every relative README link resolves locally.
- Rendered the README through GitHub's Markdown API and confirmed the emoji matrix and corrected statuses are present.
- Confirmed the previous `Partially works`, Chromium-only, and not-yet-implemented movie labels are absent.

Closes #15

Agent-Model: OpenAI GPT-5