### PR TITLE
Add trusted pull request preview deployments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,12 +44,15 @@ jobs:
       - name: Package and audit Pages artifact
         working-directory: WebAssembly
         env:
-          PAGES_SOURCE_URL: ${{ github.server_url }}/${{ github.repository }}/tree/${{ github.sha }}
+          PAGES_SOURCE_URL: ${{ github.server_url }}/${{ github.repository }}/tree/${{ github.event.pull_request.head.sha || github.sha }}
           GA_MEASUREMENT_ID: G-TEST000000
         run: |
           npm run test:pages-artifact-guard
+          npm run test:cloudflare-artifact-guard
           node tools/verify_pages_site.mjs pages-dist >"${RUNNER_TEMP}/pages-inventory.json"
+          node tools/verify_cloudflare_site.mjs cloudflare-dist >"${RUNNER_TEMP}/cloudflare-inventory.json"
           node -e 'const x=require(process.argv[1]); console.log(JSON.stringify({files:x.files,totalBytes:x.totalBytes}, null, 2))' "${RUNNER_TEMP}/pages-inventory.json"
+          node -e 'const x=require(process.argv[1]); console.log(JSON.stringify({files:x.files,totalBytes:x.totalBytes}, null, 2))' "${RUNNER_TEMP}/cloudflare-inventory.json"
 
       - name: Install Chromium
         working-directory: WebAssembly
@@ -60,3 +63,19 @@ jobs:
         env:
           PAGES_SMOKE_SCREENSHOT: ${{ runner.temp }}/pages-launcher.png
         run: npm run test:pages-deployment
+
+      - name: Prove direct-header threaded deployment
+        working-directory: WebAssembly
+        env:
+          CLOUDFLARE_SMOKE_SCREENSHOT: ${{ runner.temp }}/cloudflare-launcher.png
+        run: npm run test:cloudflare-deployment
+
+      - name: Upload trusted preview handoff
+        if: github.event.pull_request.head.repo.full_name == github.repository
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: cloudflare-preview-site
+          path: WebAssembly/cloudflare-dist
+          if-no-files-found: error
+          retention-days: 1
+          compression-level: 0

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,174 @@
+name: Deploy pull request preview
+
+on:
+  workflow_run:
+    workflows: ["Pull request CI"]
+    types: [completed]
+
+permissions:
+  actions: read
+  contents: read
+  deployments: write
+  pull-requests: read
+
+concurrency:
+  group: pr-preview-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    name: Publish trusted PR artifact
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.head_repository.full_name == github.repository
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    environment:
+      name: cloudflare-pages
+
+    env:
+      HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+      TRIGGER_RUN_ID: ${{ github.event.workflow_run.id }}
+      CLOUDFLARE_PAGES_PROJECT: ${{ vars.CLOUDFLARE_PAGES_PROJECT }}
+
+    steps:
+      - name: Resolve the current pull request
+        id: pull_request
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          pulls="$(gh api \
+            -H "Accept: application/vnd.github+json" \
+            "repos/${GITHUB_REPOSITORY}/commits/${HEAD_SHA}/pulls")"
+          match="$(jq -c \
+            --arg repo "${GITHUB_REPOSITORY}" \
+            --arg sha "${HEAD_SHA}" \
+            --arg base "${DEFAULT_BRANCH}" \
+            '[.[] | select(
+              .state == "open" and
+              .head.repo.full_name == $repo and
+              .head.sha == $sha and
+              .base.repo.full_name == $repo and
+              .base.ref == $base
+            )] | if length == 1 then .[0] else empty end' \
+            <<<"${pulls}")"
+          if [[ -z "${match}" ]]; then
+            echo "No unique open pull request still points at ${HEAD_SHA}; skipping stale handoff."
+            echo "deploy=false" >>"${GITHUB_OUTPUT}"
+            exit 0
+          fi
+          pr_number="$(jq -r '.number' <<<"${match}")"
+          preview_url="https://pr-${pr_number}.${CLOUDFLARE_PAGES_PROJECT}.pages.dev"
+          echo "deploy=true" >>"${GITHUB_OUTPUT}"
+          echo "number=${pr_number}" >>"${GITHUB_OUTPUT}"
+          echo "url=${preview_url}" >>"${GITHUB_OUTPUT}"
+
+      - name: Validate deployment configuration
+        if: steps.pull_request.outputs.deploy == 'true'
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: |
+          test -n "${CLOUDFLARE_ACCOUNT_ID}" || { echo "CLOUDFLARE_ACCOUNT_ID is not configured"; exit 1; }
+          test -n "${CLOUDFLARE_API_TOKEN}" || { echo "CLOUDFLARE_API_TOKEN is not configured"; exit 1; }
+          test -n "${CLOUDFLARE_PAGES_PROJECT}" || { echo "CLOUDFLARE_PAGES_PROJECT is not configured"; exit 1; }
+
+      - name: Download audited preview artifact
+        if: steps.pull_request.outputs.deploy == 'true'
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: cloudflare-preview-site
+          path: cloudflare-dist
+          github-token: ${{ github.token }}
+          run-id: ${{ env.TRIGGER_RUN_ID }}
+
+      - name: Set up Node 22
+        if: steps.pull_request.outputs.deploy == 'true'
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: "22"
+
+      - name: Install pinned deployment client
+        if: steps.pull_request.outputs.deploy == 'true'
+        run: npm install --global --ignore-scripts wrangler@4.110.0
+
+      - name: Create GitHub deployment
+        if: steps.pull_request.outputs.deploy == 'true'
+        id: deployment
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.pull_request.outputs.number }}
+          PREVIEW_URL: ${{ steps.pull_request.outputs.url }}
+        run: |
+          deployment_id="$(jq -n \
+            --arg ref "${HEAD_SHA}" \
+            --arg environment "pr-${PR_NUMBER}" \
+            '{
+              ref: $ref,
+              environment: $environment,
+              auto_merge: false,
+              required_contexts: [],
+              transient_environment: true,
+              production_environment: false,
+              description: "Cloudflare Pages pull request preview"
+            }' | gh api \
+              --method POST \
+              "repos/${GITHUB_REPOSITORY}/deployments" \
+              --input - \
+              --jq '.id')"
+          jq -n \
+            --arg state "in_progress" \
+            --arg url "${PREVIEW_URL}" \
+            --arg log_url "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
+            '{state: $state, environment_url: $url, log_url: $log_url}' | gh api \
+              --method POST \
+              "repos/${GITHUB_REPOSITORY}/deployments/${deployment_id}/statuses" \
+              --input - >/dev/null
+          echo "id=${deployment_id}" >>"${GITHUB_OUTPUT}"
+
+      - name: Deploy stable Cloudflare preview
+        if: steps.pull_request.outputs.deploy == 'true'
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          PR_NUMBER: ${{ steps.pull_request.outputs.number }}
+        run: >-
+          wrangler pages deploy cloudflare-dist
+          --project-name="${CLOUDFLARE_PAGES_PROJECT}"
+          --branch="pr-${PR_NUMBER}"
+          --commit-hash="${HEAD_SHA}"
+          --commit-dirty=false
+
+      - name: Mark GitHub deployment successful
+        if: steps.pull_request.outputs.deploy == 'true' && success()
+        env:
+          DEPLOYMENT_ID: ${{ steps.deployment.outputs.id }}
+          GH_TOKEN: ${{ github.token }}
+          PREVIEW_URL: ${{ steps.pull_request.outputs.url }}
+        run: |
+          jq -n \
+            --arg state "success" \
+            --arg url "${PREVIEW_URL}" \
+            --arg log_url "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
+            '{state: $state, environment_url: $url, log_url: $log_url, auto_inactive: true}' | gh api \
+              --method POST \
+              "repos/${GITHUB_REPOSITORY}/deployments/${DEPLOYMENT_ID}/statuses" \
+              --input - >/dev/null
+
+      - name: Mark GitHub deployment failed
+        if: failure() && steps.deployment.outputs.id != ''
+        env:
+          DEPLOYMENT_ID: ${{ steps.deployment.outputs.id }}
+          GH_TOKEN: ${{ github.token }}
+          PREVIEW_URL: ${{ steps.pull_request.outputs.url }}
+        run: |
+          jq -n \
+            --arg state "failure" \
+            --arg url "${PREVIEW_URL}" \
+            --arg log_url "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
+            '{state: $state, environment_url: $url, log_url: $log_url}' | gh api \
+              --method POST \
+              "repos/${GITHUB_REPOSITORY}/deployments/${DEPLOYMENT_ID}/statuses" \
+              --input - >/dev/null

--- a/WebAssembly/CLOUDFLARE.md
+++ b/WebAssembly/CLOUDFLARE.md
@@ -11,6 +11,36 @@ GitHub remains the build system and source of the audited artifact. Do not also
 connect this repository through Cloudflare's Git integration: a Pages project
 created for Direct Upload cannot later switch deployment modes.
 
+## Pull request previews
+
+Every successful pull request from a branch in this repository publishes the
+same audited direct-header artifact to a stable Cloudflare preview alias:
+
+```text
+https://pr-<number>.<project>.pages.dev/
+```
+
+GitHub attaches that URL to the pull request commit as a transient deployment,
+so the pull request shows a **View deployment** link. Later commits update the
+same alias. This stable origin is intentional: installed retail files live in
+origin-private browser storage, so changing to a per-commit hostname would make
+the player select or install those files again after every update.
+
+The preview handoff has two trust levels. `ci.yml` builds, audits, boots, and
+uploads the static `cloudflare-dist` artifact without Cloudflare credentials.
+After CI succeeds, `pr-preview.yml` runs from the workflow definition on the
+default branch, downloads that immutable artifact, and performs the upload with
+the protected `cloudflare-pages` environment. It does not check out or execute
+pull request code. Pull requests from forks are deliberately excluded because
+they are not trusted to request a credentialed deployment.
+
+No additional Cloudflare project or GitHub secret is required after the
+production setup below. The protected environment remains restricted to
+`main`: the credentialed handoff itself runs on `main`, while the artifact it
+publishes is tied to the pull request head SHA. Preview sites remain asset-free
+and never contain retail game data. Cloudflare marks preview deployments
+`noindex` automatically.
+
 ## One-time Cloudflare setup
 
 1. Create a **Pages / Direct Upload** project. Record its project name.

--- a/WebAssembly/tools/check_pages_sources.mjs
+++ b/WebAssembly/tools/check_pages_sources.mjs
@@ -62,16 +62,42 @@ for (const script of scripts.filter((name) => !name.endsWith(".sh"))) {
   }
 }
 
-for (const workflow of [
+const workflowPaths = [
   ".github/actions/setup-wasm-build/action.yml",
   ".github/workflows/ci.yml",
   ".github/workflows/cloudflare-pages.yml",
   ".github/workflows/pages.yml",
+  ".github/workflows/pr-preview.yml",
   ".github/workflows/wasm-smoke.yml",
-]) {
+];
+
+for (const workflow of workflowPaths) {
   const source = await readFile(resolve(repoRoot, workflow), "utf8");
   const document = parse(source);
   if (!document || typeof document !== "object") throw new Error(`Invalid YAML document: ${workflow}`);
+}
+
+const pullRequestWorkflow = await readFile(resolve(repoRoot, ".github/workflows/ci.yml"), "utf8");
+for (const contract of [
+  "npm run test:cloudflare-artifact-guard",
+  "npm run test:cloudflare-deployment",
+  "name: cloudflare-preview-site",
+  "github.event.pull_request.head.repo.full_name == github.repository",
+]) {
+  if (!pullRequestWorkflow.includes(contract)) throw new Error(`Pull request preview handoff missing: ${contract}`);
+}
+
+const previewWorkflow = await readFile(resolve(repoRoot, ".github/workflows/pr-preview.yml"), "utf8");
+for (const contract of [
+  'workflows: ["Pull request CI"]',
+  "github.event.workflow_run.head_repository.full_name == github.repository",
+  "github.event.workflow_run.conclusion == 'success'",
+  "name: cloudflare-pages",
+  "name: cloudflare-preview-site",
+  '--branch="pr-${PR_NUMBER}"',
+  "transient_environment: true",
+]) {
+  if (!previewWorkflow.includes(contract)) throw new Error(`Trusted preview deployment contract missing: ${contract}`);
 }
 
 const serviceWorker = await readFile(resolve(wasmRoot, "pages/coi-serviceworker.js"), "utf8");
@@ -108,4 +134,4 @@ if (shell.status !== 0) {
   throw new Error("Syntax check failed: tools/build_pages_runtime.sh");
 }
 
-console.log(`Checked ${scripts.length - 1} JavaScript files, 1 shell file, and 5 workflow YAML files.`);
+console.log(`Checked ${scripts.length - 1} JavaScript files, 1 shell file, and ${workflowPaths.length} workflow YAML files.`);


### PR DESCRIPTION
Closes #14

## What changed

- extend pull-request CI to package, audit, and boot the direct-header Cloudflare artifact
- upload the audited artifact only for branches inside `Agusx1211/NewShoes`
- add a default-branch `workflow_run` handoff that deploys the immutable artifact to a stable `pr-<number>.newshoes.pages.dev` alias
- attach the URL to the PR head as a transient GitHub deployment
- document the trust boundary, stable-origin behavior, and asset-free preview contract

## Why

Reviewers can test each browser build from a link without running a local build. A stable per-PR origin preserves OPFS-installed retail files across updates. The credentialed workflow runs from `main` and never checks out or executes PR code; fork PRs cannot request a deployment.

## Validation

- `npm --prefix WebAssembly run check:pages`
- `actionlint .github/workflows/ci.yml .github/workflows/pr-preview.yml .github/workflows/cloudflare-pages.yml`
- exercised the head-SHA-to-open-PR resolver against PR #17
- installed and ran pinned `wrangler@4.110.0` with lifecycle scripts disabled
- full threaded build and Chromium deployment gates run in PR CI