### PR TITLE
Fix inconsistent water reflections from offscreen viewports

### DIFF
--- a/WebAssembly/harness/d3d8_executor.mjs
+++ b/WebAssembly/harness/d3d8_executor.mjs
@@ -1675,7 +1675,7 @@ function syncCanvasSize(options = {}) {
     invalidateD3D8NormalizedViewportCache();
   }
   if (gl && restoreViewport) {
-    restoreFullCanvasViewport();
+    restoreFullRenderTargetViewport();
   } else if (resized) {
     invalidateD3D8AppliedViewportCache();
   }
@@ -1708,7 +1708,7 @@ function onD3D8BackbufferResize(width, height, source = "engine") {
   invalidateD3D8NormalizedViewportCache();
   invalidateD3D8AppliedViewportCache();
   if (gl) {
-    restoreFullCanvasViewport();
+    restoreFullRenderTargetViewport();
   }
   refreshCanvasState();
   recordLog("d3d8 backbuffer resize", { width: bufferWidth, height: bufferHeight, source });
@@ -1756,24 +1756,32 @@ function clampNumber(value, min, max, fallback) {
   return Math.max(min, Math.min(max, finiteNumber(value, fallback)));
 }
 
-function currentDrawingBufferSize() {
+function currentRenderSurfaceSize() {
+  if (d3d8CurrentFramebuffer !== null &&
+      d3d8CurrentFramebufferWidth > 0 && d3d8CurrentFramebufferHeight > 0) {
+    return {
+      width: d3d8CurrentFramebufferWidth,
+      height: d3d8CurrentFramebufferHeight,
+    };
+  }
   return {
     width: gl ? gl.drawingBufferWidth : canvas.width,
     height: gl ? gl.drawingBufferHeight : canvas.height,
   };
 }
 
-function restoreFullCanvasViewport() {
+function restoreFullRenderTargetViewport() {
   if (!gl) {
     return;
   }
-  gl.viewport(0, 0, gl.drawingBufferWidth, gl.drawingBufferHeight);
+  const target = currentRenderSurfaceSize();
+  gl.viewport(0, 0, target.width, target.height);
   gl.disable(gl.SCISSOR_TEST);
   gl.depthRange(0, 1);
   invalidateD3D8AppliedViewportCache();
 }
 
-function normalizeD3D8Viewport(payload = {}, drawingBuffer = currentDrawingBufferSize()) {
+function normalizeD3D8Viewport(payload = {}, drawingBuffer = currentRenderSurfaceSize()) {
   const bufferWidth = Math.max(0, drawingBuffer.width);
   const bufferHeight = Math.max(0, drawingBuffer.height);
   const requested = {
@@ -1840,7 +1848,7 @@ function normalizeD3D8Viewport(payload = {}, drawingBuffer = currentDrawingBuffe
   };
 }
 
-function currentD3D8ViewportPayload(drawingBuffer = currentDrawingBufferSize()) {
+function currentD3D8ViewportPayload(drawingBuffer = currentRenderSurfaceSize()) {
   if (d3d8ViewportState) {
     return d3d8ViewportState;
   }
@@ -1857,7 +1865,7 @@ function currentD3D8ViewportPayload(drawingBuffer = currentDrawingBufferSize()) 
 }
 
 function cachedD3D8NormalizedViewport() {
-  const drawingBuffer = currentDrawingBufferSize();
+  const drawingBuffer = currentRenderSurfaceSize();
   const bufferWidth = Math.max(0, drawingBuffer.width);
   const bufferHeight = Math.max(0, drawingBuffer.height);
   const payload = currentD3D8ViewportPayload({ width: bufferWidth, height: bufferHeight });
@@ -6357,7 +6365,7 @@ function paintD3D8Clear(flags, red, green, blue, alpha, z, stencil) {
   // Clear only touches clearColor/clearDepth/clearStencil (untracked), the
   // depth mask (via the tracked setD3D8DepthMask, restored below), the
   // stencil mask (tracked cache synced below), and — through syncCanvasSize's
-  // restoreFullCanvasViewport — viewport/scissor, whose applied-viewport cache
+  // restoreFullRenderTargetViewport — viewport/scissor, whose applied-viewport cache
   // that helper invalidates itself. The blend/cull/uniform/vertex-attrib
   // caches all stay valid, so only the pending batch needs flushing here
   // (it must draw under the pre-clear state).

--- a/WebAssembly/harness/d3d8_offscreen_viewport_smoke.mjs
+++ b/WebAssembly/harness/d3d8_offscreen_viewport_smoke.mjs
@@ -1,0 +1,162 @@
+#!/usr/bin/env node
+
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { chromium } from "playwright";
+import { startStaticServer } from "./static-server.mjs";
+
+const harnessRoot = dirname(fileURLToPath(import.meta.url));
+const wasmRoot = resolve(harnessRoot, "..");
+const server = await startStaticServer({ root: wasmRoot });
+let browser;
+
+try {
+  browser = await chromium.launch({ headless: true });
+  const page = await browser.newPage();
+  const executorUrl = new URL("harness/d3d8_executor.mjs", server.url);
+  await page.goto(executorUrl.href, { waitUntil: "load" });
+
+  const result = await page.evaluate(async (moduleUrl) => {
+    const { createD3D8Executor } = await import(moduleUrl);
+    const canvas = document.createElement("canvas");
+    canvas.width = 1920;
+    canvas.height = 1080;
+    document.body.append(canvas);
+
+    const gl = canvas.getContext("webgl2", {
+      depth: true,
+      stencil: true,
+      preserveDrawingBuffer: true,
+    });
+    if (!gl) {
+      throw new Error("WebGL2 context unavailable");
+    }
+
+    const { hooks } = createD3D8Executor({
+      canvas,
+      gl,
+      state: { graphics: {} },
+      log() {},
+    });
+
+    const expect = (condition, message, detail) => {
+      if (!condition) {
+        throw new Error(`${message}: ${JSON.stringify(detail)}`);
+      }
+    };
+    const readPixel = (x, y) => {
+      const pixel = new Uint8Array(4);
+      gl.readPixels(x, y, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, pixel);
+      return Array.from(pixel);
+    };
+    const compileShader = (type, source) => {
+      const shader = gl.createShader(type);
+      gl.shaderSource(shader, source);
+      gl.compileShader(shader);
+      expect(gl.getShaderParameter(shader, gl.COMPILE_STATUS),
+        "probe shader compilation failed", gl.getShaderInfoLog(shader));
+      return shader;
+    };
+
+    expect(hooks.cncPortD3D8TextureCreate({
+      id: 1,
+      width: 256,
+      height: 256,
+      levels: 1,
+      format: 21,
+      usage: 1,
+      pool: 0,
+    }) === 1, "render-target texture creation failed");
+    expect(hooks.cncPortD3D8BindFramebuffer({
+      colorTextureId: 1,
+      depthTextureId: 0,
+      width: 256,
+      height: 256,
+    }) === 1, "offscreen framebuffer bind failed");
+
+    hooks.cncPortD3D8Clear(1, 255, 0, 0, 255, 1, 0);
+    hooks.cncPortD3D8SetViewport({
+      x: 0,
+      y: 0,
+      width: 256,
+      height: 256,
+      minZ: 0,
+      maxZ: 1,
+      targetWidth: 256,
+      targetHeight: 256,
+    });
+
+    const offscreenViewport = Array.from(gl.getParameter(gl.VIEWPORT));
+    const offscreenScissor = Array.from(gl.getParameter(gl.SCISSOR_BOX));
+    expect(offscreenViewport.join(",") === "0,0,256,256",
+      "offscreen viewport used backbuffer dimensions", offscreenViewport);
+    expect(offscreenScissor.join(",") === "0,0,256,256",
+      "offscreen scissor used backbuffer dimensions", offscreenScissor);
+
+    const program = gl.createProgram();
+    gl.attachShader(program, compileShader(gl.VERTEX_SHADER, `#version 300 es
+      void main() {
+        vec2 position = vec2((gl_VertexID << 1) & 2, gl_VertexID & 2);
+        gl_Position = vec4(position * 2.0 - 1.0, 0.0, 1.0);
+      }
+    `));
+    gl.attachShader(program, compileShader(gl.FRAGMENT_SHADER, `#version 300 es
+      precision highp float;
+      out vec4 color;
+      void main() {
+        color = vec4(0.0, 0.0, 1.0, 1.0);
+      }
+    `));
+    gl.linkProgram(program);
+    expect(gl.getProgramParameter(program, gl.LINK_STATUS),
+      "probe program link failed", gl.getProgramInfoLog(program));
+    gl.useProgram(program);
+    gl.bindVertexArray(gl.createVertexArray());
+    gl.drawArrays(gl.TRIANGLES, 0, 3);
+
+    const samplePoints = [[1, 1], [254, 1], [128, 128], [1, 254], [254, 254]];
+    const samples = samplePoints.map(([x, y]) => readPixel(x, y));
+    expect(samples.every((pixel) => pixel.join(",") === "0,0,255,255"),
+      "fullscreen draw did not cover the offscreen target", samples);
+
+    expect(hooks.cncPortD3D8BindFramebuffer({
+      colorTextureId: 0,
+      depthTextureId: 0,
+      width: 0,
+      height: 0,
+    }) === 1, "default framebuffer restore failed");
+    hooks.cncPortD3D8SetViewport({
+      x: 0,
+      y: 0,
+      width: 1920,
+      height: 1080,
+      minZ: 0,
+      maxZ: 1,
+      targetWidth: 1920,
+      targetHeight: 1080,
+    });
+
+    const restoredViewport = Array.from(gl.getParameter(gl.VIEWPORT));
+    const restoredScissor = Array.from(gl.getParameter(gl.SCISSOR_BOX));
+    expect(restoredViewport.join(",") === "0,0,1920,1080",
+      "backbuffer viewport was not restored", restoredViewport);
+    expect(restoredScissor.join(",") === "0,0,1920,1080",
+      "backbuffer scissor was not restored", restoredScissor);
+
+    return {
+      ok: true,
+      backbuffer: [1920, 1080],
+      renderTarget: [256, 256],
+      offscreenViewport,
+      offscreenScissor,
+      samples,
+      restoredViewport,
+      restoredScissor,
+    };
+  }, executorUrl.href);
+
+  console.log(JSON.stringify(result, null, 2));
+} finally {
+  await browser?.close();
+  await server.close();
+}

--- a/WebAssembly/harness/shellmap_real_init_gate.mjs
+++ b/WebAssembly/harness/shellmap_real_init_gate.mjs
@@ -9,6 +9,13 @@ const wasmRoot = resolve(harnessRoot, "..");
 const archiveRoot = resolve(wasmRoot, "artifacts/real-assets");
 const screenshotDir = resolve(wasmRoot, "artifacts/screenshots");
 const shellmapScreenshot = resolve(screenshotDir, "shellmap-real-init-gate-canvas.png");
+const requestedWidth = Number.parseInt(process.env.CNC_SHELLMAP_WIDTH ?? "", 10);
+const requestedHeight = Number.parseInt(process.env.CNC_SHELLMAP_HEIGHT ?? "", 10);
+const requestedResolution =
+  Number.isFinite(requestedWidth) && requestedWidth > 0 &&
+  Number.isFinite(requestedHeight) && requestedHeight > 0
+    ? { width: requestedWidth, height: requestedHeight }
+    : null;
 
 // Whole-file archive set for the real GameEngine::init() lifecycle run.
 // Base Generals archives mount under ZZBase_* so Zero Hour archives keep the
@@ -180,7 +187,9 @@ try {
   browser = await chromium.launch();
   await mkdir(screenshotDir, { recursive: true });
 
-  const page = await browser.newPage({ viewport: { width: 1280, height: 720 } });
+  const page = await browser.newPage({
+    viewport: requestedResolution ?? { width: 1280, height: 720 },
+  });
   page.setDefaultTimeout(240000);
   page.setDefaultNavigationTimeout(240000);
   page.on("pageerror", (error) => {
@@ -251,11 +260,27 @@ try {
   }
   assertShellMapFrame(frame);
 
+  let resolution = null;
+  if (requestedResolution) {
+    resolution = await page.evaluate((target) =>
+      window.CnCPort.rpc("setEngineResolution", target), requestedResolution);
+    expect(resolution?.ok === true
+        && resolution?.applied?.width === requestedResolution.width
+        && resolution?.applied?.height === requestedResolution.height,
+      "real shell-map resolution change failed", resolution);
+    frame = await page.evaluate(() =>
+      window.CnCPort.rpc("realEngineFrame", { frames: 3 }));
+    assertShellMapFrame(frame);
+  }
+
   const screenshot = await page.evaluate(() => window.CnCPort.rpc("screenshot"));
   const canvas = screenshot.screenshot;
   expect(screenshot.ok === true
       && canvas?.width > 0
       && canvas?.height > 0
+      && (!requestedResolution
+        || (canvas.width === requestedResolution.width
+          && canvas.height === requestedResolution.height))
       && pixelHasColor(canvas?.centerPixel),
     "shell-map canvas center stayed blank", {
       ok: screenshot.ok,
@@ -277,6 +302,7 @@ try {
     objectCount: clientState.gameplay.objectCount,
     drawableCount: clientState.gameplay.drawableCount,
     renderedObjectCount: clientState.gameplay.renderedObjectCount,
+    resolution: resolution?.applied ?? null,
     canvasSize: { width: canvas.width, height: canvas.height },
     centerPixel: canvas.centerPixel,
     screenshot: relative(wasmRoot, shellmapScreenshot),

--- a/WebAssembly/package.json
+++ b/WebAssembly/package.json
@@ -156,6 +156,7 @@
     "test:w3d-device-utility": "npm run build:wasm && node dist/w3d-device-utility-smoke.cjs",
     "test:ww3d2-light-render": "npm run build:wasm && node dist/ww3d2-light-render-smoke.cjs",
     "test:d3d8-shim": "npm run build:wasm && node dist/d3d8-shim-smoke.cjs",
+    "test:d3d8-offscreen-viewport-browser": "node harness/d3d8_offscreen_viewport_smoke.mjs",
     "test:d3d8-render-state-mapping": "npm run build:wasm && node dist/d3d8-render-state-mapping-smoke.cjs",
     "test:d3d8-texture-upload-readiness": "npm run build:wasm && node dist/d3d8-texture-upload-readiness-smoke.cjs",
     "test:d3d8-texture-stage-state-mapping": "npm run build:wasm && node dist/d3d8-texture-stage-state-mapping-smoke.cjs",

--- a/WebAssembly/src/wasm_d3d8_shim.cpp
+++ b/WebAssembly/src/wasm_d3d8_shim.cpp
@@ -3937,13 +3937,15 @@ public:
 		if (depth_stencil != nullptr) {
 			depth_stencil->AddRef();
 		}
-		if (m_back_buffer != nullptr) {
-			m_back_buffer->Release();
+		if (render_target != nullptr) {
+			if (m_back_buffer != nullptr) {
+				m_back_buffer->Release();
+			}
+			m_back_buffer = render_target;
 		}
 		if (m_depth_stencil != nullptr) {
 			m_depth_stencil->Release();
 		}
-		m_back_buffer = render_target;
 		m_depth_stencil = depth_stencil;
 
 		// Resolve texture IDs for FBO binding
@@ -3952,12 +3954,12 @@ public:
 		UINT width = 0;
 		UINT height = 0;
 
-		if (render_target != nullptr && render_target != m_default_render_target) {
+		if (m_back_buffer != nullptr && m_back_buffer != m_default_render_target) {
 			// Offscreen render target: get its texture ID and dimensions
-			BrowserD3DSurface *browser_surface = static_cast<BrowserD3DSurface *>(render_target);
+			BrowserD3DSurface *browser_surface = static_cast<BrowserD3DSurface *>(m_back_buffer);
 			color_texture_id = browser_surface->texture_owner_id();
 			D3DSURFACE_DESC desc;
-			if (SUCCEEDED(render_target->GetDesc(&desc))) {
+			if (SUCCEEDED(m_back_buffer->GetDesc(&desc))) {
 				width = desc.Width;
 				height = desc.Height;
 			}
@@ -3974,6 +3976,12 @@ public:
 		// Track current FBO state
 		m_current_fbo_color_texture_id = color_texture_id;
 		m_current_fbo_depth_texture_id = depth_texture_id;
+
+		// D3D8 resets the viewport to the full current render target on every
+		// SetRenderTarget call.  This is also what makes subsequent camera
+		// viewports use the offscreen surface dimensions rather than the main
+		// backbuffer dimensions.
+		reset_viewport_to_render_target();
 
 		return S_OK;
 	}
@@ -4093,15 +4101,7 @@ public:
 		m_viewport = *viewport;
 		g_state.viewport = m_viewport;
 		++g_state.set_viewport_calls;
-		wasm_d3d8_browser_set_viewport(
-			m_viewport.X,
-			m_viewport.Y,
-			m_viewport.Width,
-			m_viewport.Height,
-			m_viewport.MinZ,
-			m_viewport.MaxZ,
-			m_parameters.BackBufferWidth,
-			m_parameters.BackBufferHeight);
+		apply_browser_viewport();
 		return S_OK;
 	}
 
@@ -5528,6 +5528,52 @@ private:
 		}
 		*surface = new (std::nothrow) BrowserD3DSurface(this, width, height, format, usage);
 		return *surface != nullptr ? S_OK : D3DERR_OUTOFVIDEOMEMORY;
+	}
+
+	void get_render_target_size(UINT &width, UINT &height) const
+	{
+		width = m_parameters.BackBufferWidth;
+		height = m_parameters.BackBufferHeight;
+		if (m_back_buffer == nullptr) {
+			return;
+		}
+
+		D3DSURFACE_DESC description = {};
+		if (SUCCEEDED(m_back_buffer->GetDesc(&description))) {
+			width = description.Width;
+			height = description.Height;
+		}
+	}
+
+	void apply_browser_viewport()
+	{
+		UINT target_width = 0;
+		UINT target_height = 0;
+		get_render_target_size(target_width, target_height);
+		wasm_d3d8_browser_set_viewport(
+			m_viewport.X,
+			m_viewport.Y,
+			m_viewport.Width,
+			m_viewport.Height,
+			m_viewport.MinZ,
+			m_viewport.MaxZ,
+			target_width,
+			target_height);
+	}
+
+	void reset_viewport_to_render_target()
+	{
+		UINT target_width = 0;
+		UINT target_height = 0;
+		get_render_target_size(target_width, target_height);
+		m_viewport.X = 0;
+		m_viewport.Y = 0;
+		m_viewport.Width = target_width;
+		m_viewport.Height = target_height;
+		m_viewport.MinZ = 0.0f;
+		m_viewport.MaxZ = 1.0f;
+		g_state.viewport = m_viewport;
+		apply_browser_viewport();
 	}
 
 	ULONG m_ref_count = 1;

--- a/WebAssembly/tests/d3d8_shim_smoke.cpp
+++ b/WebAssembly/tests/d3d8_shim_smoke.cpp
@@ -1204,13 +1204,80 @@ int main()
 		expect(state->browser_buffer_create_calls >= 2, "browser buffer create count mismatch") &&
 		expect(state->browser_buffer_update_calls >= 4, "browser buffer update count mismatch");
 
+	// SetRenderTarget resets the D3D8 viewport to the active surface size.  The
+	// browser bridge also relies on this state to distinguish a small RTT from
+	// the main backbuffer when it converts the top-left D3D viewport to WebGL.
+	IDirect3DSurface8 *default_render_target = nullptr;
+	IDirect3DSurface8 *default_depth_stencil = nullptr;
+	IDirect3DTexture8 *offscreen_texture = nullptr;
+	IDirect3DSurface8 *offscreen_render_target = nullptr;
+	D3DVIEWPORT8 offscreen_viewport = {};
+	D3DVIEWPORT8 depth_only_viewport = {};
+	D3DVIEWPORT8 restored_viewport = {};
+	D3DVIEWPORT8 partial_viewport = {};
+	partial_viewport.X = 4;
+	partial_viewport.Y = 2;
+	partial_viewport.Width = 32;
+	partial_viewport.Height = 16;
+	partial_viewport.MinZ = 0.25f;
+	partial_viewport.MaxZ = 0.75f;
+	const bool render_target_viewport_ok =
+		expect(SUCCEEDED(device->GetRenderTarget(&default_render_target)),
+			"GetRenderTarget for viewport reset failed") &&
+		expect(SUCCEEDED(device->GetDepthStencilSurface(&default_depth_stencil)),
+			"GetDepthStencilSurface for viewport reset failed") &&
+		expect(SUCCEEDED(device->CreateTexture(64, 32, 1, D3DUSAGE_RENDERTARGET,
+			D3DFMT_A8R8G8B8, D3DPOOL_DEFAULT, &offscreen_texture)),
+			"CreateTexture for viewport reset failed") &&
+		expect(SUCCEEDED(offscreen_texture->GetSurfaceLevel(0, &offscreen_render_target)),
+			"GetSurfaceLevel for viewport reset failed") &&
+		expect(SUCCEEDED(device->SetRenderTarget(offscreen_render_target, nullptr)),
+			"SetRenderTarget to offscreen surface failed") &&
+		expect(SUCCEEDED(device->GetViewport(&offscreen_viewport)),
+			"GetViewport for offscreen surface failed") &&
+		expect(offscreen_viewport.X == 0 && offscreen_viewport.Y == 0 &&
+			offscreen_viewport.Width == 64 && offscreen_viewport.Height == 32 &&
+			near(offscreen_viewport.MinZ, 0.0f) && near(offscreen_viewport.MaxZ, 1.0f),
+			"offscreen render target did not reset viewport") &&
+		expect(SUCCEEDED(device->SetViewport(&partial_viewport)),
+			"SetViewport before depth-only render target change failed") &&
+		expect(SUCCEEDED(device->SetRenderTarget(nullptr, default_depth_stencil)),
+			"depth-only SetRenderTarget failed") &&
+		expect(SUCCEEDED(device->GetViewport(&depth_only_viewport)),
+			"GetViewport after depth-only render target change failed") &&
+		expect(depth_only_viewport.X == 0 && depth_only_viewport.Y == 0 &&
+			depth_only_viewport.Width == 64 && depth_only_viewport.Height == 32 &&
+			near(depth_only_viewport.MinZ, 0.0f) && near(depth_only_viewport.MaxZ, 1.0f),
+			"depth-only render target change did not retain the offscreen viewport") &&
+		expect(SUCCEEDED(device->SetRenderTarget(default_render_target, default_depth_stencil)),
+			"SetRenderTarget to default surface failed") &&
+		expect(SUCCEEDED(device->GetViewport(&restored_viewport)),
+			"GetViewport for restored surface failed") &&
+		expect(restored_viewport.X == 0 && restored_viewport.Y == 0 &&
+			restored_viewport.Width == 640 && restored_viewport.Height == 360 &&
+			near(restored_viewport.MinZ, 0.0f) && near(restored_viewport.MaxZ, 1.0f),
+			"default render target did not restore full viewport");
+
+	if (offscreen_render_target != nullptr) {
+		offscreen_render_target->Release();
+	}
+	if (offscreen_texture != nullptr) {
+		offscreen_texture->Release();
+	}
+	if (default_depth_stencil != nullptr) {
+		default_depth_stencil->Release();
+	}
+	if (default_render_target != nullptr) {
+		default_render_target->Release();
+	}
+
 	device->Release();
 	d3d->Release();
 
 	const bool release_ok =
 		expect(state->browser_buffer_release_calls >= 2, "browser buffer release count mismatch");
 
-	if (!state_ok || !release_ok) {
+	if (!state_ok || !render_target_viewport_ok || !release_ok) {
 		return 1;
 	}
 


### PR DESCRIPTION
## Summary

- size D3D8 viewports against the active render target instead of the main backbuffer
- reset the viewport when `SetRenderTarget` changes or retains the color target, matching D3D8 semantics
- make the WebGL executor normalize and restore viewport/scissor state against the bound framebuffer
- add native shim and browser pixel regressions, plus configurable high-resolution shell-map verification

## Root cause

Type 2 water renders its reflection into a 256×256 texture. At larger game resolutions, the shim passed the main backbuffer dimensions into the D3D8-to-WebGL viewport conversion, and the executor also normalized against the canvas drawing buffer. At 1920×1080 this converted the reflection viewport to `[0,824,256,256]`, entirely outside the 256×256 framebuffer, leaving stale or empty reflection data and producing inconsistent water.

## Verification

- `npm run test:d3d8-offscreen-viewport-browser`
- `CNC_BUILD_TARGETS=d3d8-shim-smoke bash tools/build_wasm.sh`
- `node dist/d3d8-shim-smoke.cjs`
- `npm run build:port`
- `EXPECT_WASM=1 node harness/smoke.mjs`
- `CNC_SHELLMAP_WIDTH=1920 CNC_SHELLMAP_HEIGHT=1080 node harness/shellmap_real_init_gate.mjs`

The browser regression verifies all four corners and the center of the 256×256 target are updated at a 1920×1080 backbuffer resolution. The real shell-map gate rendered successfully at 1920×1080 with the water surface visually coherent.

Fixes #10