### PR TITLE
Add dedicated Trystero discovery relay

### DIFF
--- a/.github/workflows/trystero-relay.yml
+++ b/.github/workflows/trystero-relay.yml
@@ -1,0 +1,74 @@
+name: Deploy Trystero Relay
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/trystero-relay.yml"
+      - "WebAssembly/cloudflare/trystero-relay/**"
+      - "WebAssembly/harness/trystero_relay_worker_smoke.mjs"
+      - "WebAssembly/package.json"
+      - "WebAssembly/package-lock.json"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: trystero-relay-production
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Verify and deploy dedicated relay
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    environment:
+      name: cloudflare-relay
+      url: https://relay.newshoes.gg/health
+
+    steps:
+      - name: Check out source
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Set up Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: WebAssembly/package-lock.json
+
+      - name: Install dependencies
+        working-directory: WebAssembly
+        run: npm ci
+
+      - name: Verify relay protocol locally
+        working-directory: WebAssembly
+        run: npm run test:trystero-relay
+
+      - name: Validate Cloudflare credentials
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: |
+          test -n "${CLOUDFLARE_ACCOUNT_ID}" || { echo "CLOUDFLARE_ACCOUNT_ID is not configured"; exit 1; }
+          test -n "${CLOUDFLARE_API_TOKEN}" || { echo "CLOUDFLARE_API_TOKEN is not configured"; exit 1; }
+
+      - name: Deploy relay Worker and Durable Object
+        working-directory: WebAssembly
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: npx wrangler deploy --config cloudflare/trystero-relay/wrangler.jsonc
+
+      - name: Verify deployed health endpoint
+        run: |
+          for attempt in $(seq 1 20); do
+            if curl --fail --silent --show-error https://relay.newshoes.gg/health | grep -q '"ok":true'; then
+              exit 0
+            fi
+            sleep 3
+          done
+          echo "deployed relay health endpoint did not become ready"
+          exit 1

--- a/WebAssembly/cloudflare/trystero-relay/.gitignore
+++ b/WebAssembly/cloudflare/trystero-relay/.gitignore
@@ -1,0 +1,1 @@
+.wrangler/

--- a/WebAssembly/cloudflare/trystero-relay/README.md
+++ b/WebAssembly/cloudflare/trystero-relay/README.md
@@ -1,0 +1,29 @@
+# Trystero discovery relay
+
+This Worker is the project-owned discovery/signaling relay for browser
+multiplayer. It implements the narrow Nostr NIP-01 subset used by Trystero
+0.25.2 and routes all WebSocket connections through one hibernating Durable
+Object. Game datagrams never pass through this service; after discovery they
+travel directly between peers over encrypted WebRTC data channels.
+
+The relay validates event hashes and Schnorr signatures, accepts only
+Trystero's ephemeral event-kind and `x`-topic shape, bounds subscriptions and
+message sizes, retains at most 512 events for two minutes, and permits browser
+connections only from the configured Project New Shoes origins. The Origin
+check is an abuse-reduction boundary, not authentication: non-browser clients
+can forge that header. Do not put secrets in the browser configuration or in
+Nostr events.
+
+Run the local Worker protocol gate with:
+
+```sh
+cd WebAssembly
+npm run test:trystero-relay
+```
+
+Production deployment is owned by `.github/workflows/trystero-relay.yml`. The
+`cloudflare-relay` GitHub environment needs `CLOUDFLARE_ACCOUNT_ID` and a
+`CLOUDFLARE_API_TOKEN` with Workers Scripts, Durable Objects, and DNS/custom
+hostname permissions for `newshoes.gg`. The deployed WebSocket endpoint is
+`wss://relay.newshoes.gg/nostr`; `https://relay.newshoes.gg/health` is a
+credential-free liveness check.

--- a/WebAssembly/cloudflare/trystero-relay/worker.mjs
+++ b/WebAssembly/cloudflare/trystero-relay/worker.mjs
@@ -1,0 +1,336 @@
+import { schnorr } from "@noble/secp256k1";
+
+const SERVICE = "newshoes-trystero-nostr-relay";
+const EVENT_PREFIX = "event:";
+const EVENT_INDEX_KEY = "event-index";
+const SUBSCRIPTION_PREFIX = "subscriptions:";
+const MAX_MESSAGE_BYTES = 256 * 1024;
+const MAX_RETAINED_EVENTS = 512;
+const MAX_EVENT_AGE_SECONDS = 120;
+const MAX_FUTURE_SKEW_SECONDS = 60;
+const MAX_SUBSCRIPTIONS = 64;
+const MAX_FILTERS = 4;
+const MAX_TOPICS_PER_FILTER = 250;
+const TRYSTERO_KIND_MIN = 20000;
+const TRYSTERO_KIND_MAX = 29999;
+const HEX_32 = /^[0-9a-f]{64}$/;
+const HEX_64 = /^[0-9a-f]{128}$/;
+const TRYSTERO_TOPIC = /^[0-9a-z]{20,40}$/;
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+function hexBytes(value) {
+  const bytes = new Uint8Array(value.length / 2);
+  for (let index = 0; index < bytes.length; ++index) {
+    bytes[index] = Number.parseInt(value.slice(index * 2, index * 2 + 2), 16);
+  }
+  return bytes;
+}
+
+function jsonResponse(value, status = 200) {
+  return new Response(JSON.stringify(value), {
+    status,
+    headers: {
+      "content-type": "application/json; charset=utf-8",
+      "cache-control": "no-store",
+    },
+  });
+}
+
+function allowedOrigin(request, env) {
+  const origin = request.headers.get("origin");
+  if (!origin) return false;
+  let hostname;
+  try {
+    hostname = new URL(origin).hostname.toLowerCase();
+  } catch {
+    return false;
+  }
+  const exact = String(env.ALLOWED_ORIGIN_HOSTS ?? "")
+    .split(",").map((host) => host.trim().toLowerCase()).filter(Boolean);
+  const suffixes = String(env.ALLOWED_ORIGIN_SUFFIXES ?? "")
+    .split(",").map((suffix) => suffix.trim().toLowerCase()).filter(Boolean);
+  return exact.includes(hostname)
+    || suffixes.some((suffix) => suffix.startsWith(".") && hostname.endsWith(suffix));
+}
+
+function eventTopics(event) {
+  if (!Array.isArray(event?.tags)) return [];
+  return event.tags
+    .filter((tag) => Array.isArray(tag) && tag[0] === "x" && typeof tag[1] === "string")
+    .map((tag) => tag[1]);
+}
+
+export function matchesFilter(event, filter) {
+  if (!event || !filter || typeof event !== "object" || typeof filter !== "object") return false;
+  if (Array.isArray(filter.ids) && !filter.ids.some((id) => event.id.startsWith(id))) return false;
+  if (Array.isArray(filter.authors)
+      && !filter.authors.some((author) => event.pubkey.startsWith(author))) return false;
+  if (Array.isArray(filter.kinds) && !filter.kinds.includes(event.kind)) return false;
+  if (Number.isFinite(filter.since) && event.created_at < filter.since) return false;
+  if (Number.isFinite(filter.until) && event.created_at > filter.until) return false;
+  if (Array.isArray(filter["#x"])) {
+    const topics = eventTopics(event);
+    if (!filter["#x"].some((topic) => topics.includes(topic))) return false;
+  }
+  return true;
+}
+
+function validFilter(filter) {
+  if (!filter || typeof filter !== "object" || Array.isArray(filter)) return false;
+  if (filter.ids != null
+      && (!Array.isArray(filter.ids)
+        || filter.ids.some((id) => typeof id !== "string" || !/^[0-9a-f]{1,64}$/.test(id)))) {
+    return false;
+  }
+  if (filter.authors != null
+      && (!Array.isArray(filter.authors)
+        || filter.authors.some((author) =>
+          typeof author !== "string" || !/^[0-9a-f]{1,64}$/.test(author)))) {
+    return false;
+  }
+  if (filter["#x"] != null
+      && (!Array.isArray(filter["#x"])
+        || filter["#x"].length > MAX_TOPICS_PER_FILTER
+        || filter["#x"].some((topic) => typeof topic !== "string" || !TRYSTERO_TOPIC.test(topic)))) {
+    return false;
+  }
+  if (filter.kinds != null
+      && (!Array.isArray(filter.kinds)
+        || filter.kinds.some((kind) => !Number.isInteger(kind)
+          || kind < TRYSTERO_KIND_MIN || kind > TRYSTERO_KIND_MAX))) {
+    return false;
+  }
+  if (filter.since != null && !Number.isInteger(filter.since)) return false;
+  if (filter.until != null && !Number.isInteger(filter.until)) return false;
+  return true;
+}
+
+async function sha256Hex(value) {
+  const digest = await crypto.subtle.digest("SHA-256", encoder.encode(value));
+  return [...new Uint8Array(digest)].map((byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+async function validateEvent(event, nowSeconds) {
+  if (!event || typeof event !== "object" || Array.isArray(event)) return "event must be an object";
+  if (!HEX_32.test(event.id ?? "")) return "event id must be 32-byte lowercase hex";
+  if (!HEX_32.test(event.pubkey ?? "")) return "pubkey must be 32-byte lowercase hex";
+  if (!HEX_64.test(event.sig ?? "")) return "signature must be 64-byte lowercase hex";
+  if (!Number.isInteger(event.created_at)
+      || event.created_at < nowSeconds - MAX_EVENT_AGE_SECONDS
+      || event.created_at > nowSeconds + MAX_FUTURE_SKEW_SECONDS) {
+    return "event timestamp is outside the relay retention window";
+  }
+  if (!Number.isInteger(event.kind)
+      || event.kind < TRYSTERO_KIND_MIN || event.kind > TRYSTERO_KIND_MAX) {
+    return "event kind is outside the Trystero range";
+  }
+  if (!Array.isArray(event.tags) || eventTopics(event).length !== 1
+      || !TRYSTERO_TOPIC.test(eventTopics(event)[0])) {
+    return "event must contain exactly one Trystero x topic tag";
+  }
+  if (typeof event.content !== "string" || encoder.encode(event.content).byteLength > MAX_MESSAGE_BYTES) {
+    return "event content is missing or too large";
+  }
+  const expectedId = await sha256Hex(JSON.stringify([
+    0, event.pubkey, event.created_at, event.kind, event.tags, event.content,
+  ]));
+  if (expectedId !== event.id) return "event id does not match its payload";
+  try {
+    if (!await schnorr.verifyAsync(
+      hexBytes(event.sig), hexBytes(event.id), hexBytes(event.pubkey),
+    )) {
+      return "event signature is invalid";
+    }
+  } catch {
+    return "event signature is invalid";
+  }
+  return null;
+}
+
+function send(socket, message) {
+  try {
+    socket.send(JSON.stringify(message));
+  } catch {
+    // The close/error callback owns cleanup for disconnected sockets.
+  }
+}
+
+export default {
+  async fetch(request, env) {
+    const url = new URL(request.url);
+    if (url.pathname === "/" || url.pathname === "/health") {
+      return jsonResponse({
+        ok: true,
+        service: SERVICE,
+        protocol: "nostr-nip-01-trystero-subset",
+        gameplayTraffic: false,
+      });
+    }
+    if (url.pathname !== "/nostr") return new Response("Not found", { status: 404 });
+    if (request.headers.get("upgrade")?.toLowerCase() !== "websocket") {
+      return new Response("Expected a WebSocket upgrade", { status: 426 });
+    }
+    if (!allowedOrigin(request, env)) return new Response("Origin is not allowed", { status: 403 });
+    return env.TRYSTERO_RELAY.getByName("global").fetch(request);
+  },
+};
+
+export class TrysteroNostrRelay {
+  constructor(ctx) {
+    this.ctx = ctx;
+    this.sessions = new Map();
+    const sockets = ctx.getWebSockets();
+    for (const socket of sockets) {
+      const attachment = socket.deserializeAttachment();
+      if (attachment?.id) this.sessions.set(socket, { id: attachment.id, subscriptions: new Map() });
+    }
+    ctx.blockConcurrencyWhile(async () => {
+      await Promise.all([...this.sessions.entries()].map(async ([socket, session]) => {
+        const saved = await ctx.storage.get(`${SUBSCRIPTION_PREFIX}${session.id}`);
+        session.subscriptions = new Map(Array.isArray(saved) ? saved : []);
+        this.sessions.set(socket, session);
+      }));
+    });
+  }
+
+  async fetch(request) {
+    if (this.ctx.getWebSockets().length >= 4096) {
+      return new Response("Relay connection capacity reached", { status: 503 });
+    }
+    const pair = new WebSocketPair();
+    const [client, server] = Object.values(pair);
+    const id = crypto.randomUUID();
+    server.serializeAttachment({ id });
+    this.ctx.acceptWebSocket(server);
+    this.sessions.set(server, { id, subscriptions: new Map() });
+    return new Response(null, { status: 101, webSocket: client });
+  }
+
+  async retainedEvents(filters) {
+    const index = await this.ctx.storage.get(EVENT_INDEX_KEY) ?? [];
+    if (!Array.isArray(index) || index.length === 0) return [];
+    const stored = await this.ctx.storage.get(index.map(({ id }) => `${EVENT_PREFIX}${id}`));
+    return index
+      .map(({ id }) => stored.get(`${EVENT_PREFIX}${id}`))
+      .filter((event) => event && filters.some((filter) => matchesFilter(event, filter)));
+  }
+
+  async storeEvent(event, nowSeconds) {
+    let duplicate = false;
+    await this.ctx.storage.transaction(async (txn) => {
+      const current = await txn.get(EVENT_INDEX_KEY) ?? [];
+      if (current.some(({ id }) => id === event.id)) {
+        duplicate = true;
+        return;
+      }
+      const retained = current
+        .filter((entry) => entry.created_at >= nowSeconds - MAX_EVENT_AGE_SECONDS)
+        .concat({ id: event.id, created_at: event.created_at });
+      const pruned = retained.splice(0, Math.max(0, retained.length - MAX_RETAINED_EVENTS));
+      if (pruned.length > 0) {
+        await txn.delete(pruned.map(({ id }) => `${EVENT_PREFIX}${id}`));
+      }
+      await txn.put({
+        [`${EVENT_PREFIX}${event.id}`]: event,
+        [EVENT_INDEX_KEY]: retained,
+      });
+    });
+    return duplicate;
+  }
+
+  async persistSubscriptions(session) {
+    await this.ctx.storage.put(
+      `${SUBSCRIPTION_PREFIX}${session.id}`,
+      [...session.subscriptions.entries()],
+    );
+  }
+
+  async webSocketMessage(socket, rawMessage) {
+    const bytes = typeof rawMessage === "string"
+      ? encoder.encode(rawMessage)
+      : new Uint8Array(rawMessage);
+    if (bytes.byteLength > MAX_MESSAGE_BYTES) {
+      send(socket, ["NOTICE", "message is too large"]);
+      return;
+    }
+    let message;
+    try {
+      message = JSON.parse(typeof rawMessage === "string" ? rawMessage : decoder.decode(bytes));
+    } catch {
+      send(socket, ["NOTICE", "invalid JSON"]);
+      return;
+    }
+    const session = this.sessions.get(socket);
+    if (!session || !Array.isArray(message)) return;
+    const [type, first, ...rest] = message;
+    if (type === "REQ") {
+      if (typeof first !== "string" || first.length === 0 || first.length > 128
+          || rest.length === 0 || rest.length > MAX_FILTERS || !rest.every(validFilter)) {
+        send(socket, ["CLOSED", typeof first === "string" ? first : "", "invalid: unsupported filter"]);
+        return;
+      }
+      if (!session.subscriptions.has(first) && session.subscriptions.size >= MAX_SUBSCRIPTIONS) {
+        send(socket, ["CLOSED", first, "restricted: subscription limit reached"]);
+        return;
+      }
+      session.subscriptions.set(first, rest);
+      await this.persistSubscriptions(session);
+      for (const event of await this.retainedEvents(rest)) send(socket, ["EVENT", first, event]);
+      send(socket, ["EOSE", first]);
+      return;
+    }
+    if (type === "CLOSE") {
+      if (typeof first === "string") {
+        session.subscriptions.delete(first);
+        await this.persistSubscriptions(session);
+      }
+      return;
+    }
+    if (type === "EVENT") {
+      const event = first;
+      const error = await validateEvent(event, Math.floor(Date.now() / 1000));
+      if (error) {
+        console.warn("Rejected Trystero Nostr event", {
+          reason: error,
+          id: typeof event?.id === "string" ? event.id : null,
+          kind: event?.kind ?? null,
+          topicShapes: eventTopics(event).map((topic) => ({
+            length: topic.length,
+            lowercaseHex: /^[0-9a-f]+$/.test(topic),
+          })),
+        });
+        send(socket, ["OK", event?.id ?? "", false, `invalid: ${error}`]);
+        return;
+      }
+      const duplicate = await this.storeEvent(event, Math.floor(Date.now() / 1000));
+      if (!duplicate) {
+        for (const [target, targetSession] of this.sessions) {
+          for (const [subscriptionId, filters] of targetSession.subscriptions) {
+            if (filters.some((filter) => matchesFilter(event, filter))) {
+              send(target, ["EVENT", subscriptionId, event]);
+            }
+          }
+        }
+      }
+      send(socket, ["OK", event.id, true, duplicate ? "duplicate: already stored" : ""]);
+      return;
+    }
+    send(socket, ["NOTICE", "unsupported Nostr message"]);
+  }
+
+  async removeSession(socket) {
+    const session = this.sessions.get(socket);
+    this.sessions.delete(socket);
+    if (session) await this.ctx.storage.delete(`${SUBSCRIPTION_PREFIX}${session.id}`);
+  }
+
+  async webSocketClose(socket, code, reason) {
+    await this.removeSession(socket);
+    socket.close(code, reason);
+  }
+
+  async webSocketError(socket) {
+    await this.removeSession(socket);
+  }
+}

--- a/WebAssembly/cloudflare/trystero-relay/wrangler.jsonc
+++ b/WebAssembly/cloudflare/trystero-relay/wrangler.jsonc
@@ -1,0 +1,35 @@
+{
+  "$schema": "../../node_modules/wrangler/config-schema.json",
+  "name": "newshoes-trystero-relay",
+  "main": "worker.mjs",
+  "compatibility_date": "2026-07-12",
+  "workers_dev": true,
+  "routes": [
+    {
+      "pattern": "relay.newshoes.gg",
+      "custom_domain": true
+    }
+  ],
+  "durable_objects": {
+    "bindings": [
+      {
+        "name": "TRYSTERO_RELAY",
+        "class_name": "TrysteroNostrRelay"
+      }
+    ]
+  },
+  "migrations": [
+    {
+      "tag": "v1",
+      "new_sqlite_classes": ["TrysteroNostrRelay"]
+    }
+  ],
+  "vars": {
+    "ALLOWED_ORIGIN_HOSTS": "newshoes.gg,www.newshoes.gg,agusx1211.github.io,127.0.0.1,localhost",
+    "ALLOWED_ORIGIN_SUFFIXES": ".newshoes.pages.dev"
+  },
+  "observability": {
+    "enabled": true,
+    "head_sampling_rate": 0.1
+  }
+}

--- a/WebAssembly/harness/trystero_relay_worker_smoke.mjs
+++ b/WebAssembly/harness/trystero_relay_worker_smoke.mjs
@@ -1,0 +1,164 @@
+#!/usr/bin/env node
+
+import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { schnorr, utils } from "@noble/secp256k1";
+import WebSocket from "ws";
+
+const wasmRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const config = resolve(wasmRoot, "cloudflare/trystero-relay/wrangler.jsonc");
+const port = Number.parseInt(process.env.CNC_TRYSTERO_RELAY_TEST_PORT ?? "18920", 10);
+const baseUrl = `http://127.0.0.1:${port}`;
+const socketUrl = `ws://127.0.0.1:${port}/nostr`;
+const child = spawn(process.execPath, [
+  resolve(wasmRoot, "node_modules/wrangler/bin/wrangler.js"),
+  "dev", "--local", "--ip", "127.0.0.1", "--port", String(port), "--config", config,
+], { cwd: wasmRoot, stdio: ["ignore", "pipe", "pipe"] });
+let childOutput = "";
+child.stdout.on("data", (chunk) => { childOutput += chunk; });
+child.stderr.on("data", (chunk) => { childOutput += chunk; });
+
+function expect(condition, message, payload = null) {
+  if (!condition) throw new Error(`${message}: ${JSON.stringify(payload)}`);
+}
+
+function hexBytes(value) {
+  return Uint8Array.from(Buffer.from(value, "hex"));
+}
+
+async function waitForHealth() {
+  const deadline = Date.now() + 30000;
+  while (Date.now() < deadline) {
+    if (child.exitCode != null) throw new Error(`wrangler exited early: ${childOutput}`);
+    try {
+      const response = await fetch(`${baseUrl}/health`);
+      if (response.ok) return response.json();
+    } catch {
+      // Wrangler has not bound its local port yet.
+    }
+    await new Promise((resolveWait) => setTimeout(resolveWait, 100));
+  }
+  throw new Error(`timed out waiting for relay Worker: ${childOutput}`);
+}
+
+function connect(origin = "https://newshoes.gg") {
+  return new Promise((resolveConnect, reject) => {
+    const socket = new WebSocket(socketUrl, { headers: { Origin: origin } });
+    const messages = [];
+    const waiters = [];
+    socket.on("message", (data) => {
+      const message = JSON.parse(String(data));
+      const waiterIndex = waiters.findIndex(({ predicate }) => predicate(message));
+      if (waiterIndex >= 0) {
+        const [{ resolve: resolveWaiter, timer }] = waiters.splice(waiterIndex, 1);
+        clearTimeout(timer);
+        resolveWaiter(message);
+      } else {
+        messages.push(message);
+      }
+    });
+    socket.once("open", () => resolveConnect({
+      socket,
+      next(predicate, timeoutMs = 5000) {
+        const messageIndex = messages.findIndex(predicate);
+        if (messageIndex >= 0) return Promise.resolve(messages.splice(messageIndex, 1)[0]);
+        return new Promise((resolveMessage, rejectMessage) => {
+          const waiter = { predicate, resolve: resolveMessage, timer: null };
+          waiters.push(waiter);
+          waiter.timer = setTimeout(() => {
+            const index = waiters.indexOf(waiter);
+            if (index >= 0) waiters.splice(index, 1);
+            rejectMessage(new Error(`timed out waiting for relay message; queued=${JSON.stringify(messages)}`));
+          }, timeoutMs);
+        });
+      },
+    }));
+    socket.once("error", reject);
+  });
+}
+
+async function signedEvent(topic, content) {
+  const secretKey = utils.randomSecretKey();
+  const pubkey = Buffer.from(schnorr.getPublicKey(secretKey)).toString("hex");
+  const event = {
+    pubkey,
+    created_at: Math.floor(Date.now() / 1000),
+    kind: 23456,
+    tags: [["x", topic]],
+    content,
+  };
+  event.id = createHash("sha256")
+    .update(JSON.stringify([0, event.pubkey, event.created_at, event.kind, event.tags, event.content]))
+    .digest("hex");
+  event.sig = Buffer.from(await schnorr.signAsync(hexBytes(event.id), secretKey)).toString("hex");
+  return event;
+}
+
+const sockets = [];
+try {
+  const health = await waitForHealth();
+  expect(health.ok === true && health.gameplayTraffic === false,
+    "relay health contract is incorrect", health);
+
+  const subscriber = await connect();
+  const publisher = await connect();
+  sockets.push(subscriber.socket, publisher.socket);
+  const topic = "a".repeat(40);
+  const subscriptionId = "live-subscription";
+  subscriber.socket.send(JSON.stringify([
+    "REQ", subscriptionId, { kinds: [23456], since: Math.floor(Date.now() / 1000), "#x": [topic] },
+  ]));
+  await subscriber.next((message) => message[0] === "EOSE" && message[1] === subscriptionId);
+
+  const event = await signedEvent(topic, "encrypted-trystero-sdp");
+  publisher.socket.send(JSON.stringify(["EVENT", event]));
+  const [delivered, accepted] = await Promise.all([
+    subscriber.next((message) => message[0] === "EVENT" && message[2]?.id === event.id),
+    publisher.next((message) => message[0] === "OK" && message[1] === event.id),
+  ]);
+  expect(delivered[2].content === event.content && accepted[2] === true,
+    "valid signed event was not routed", { delivered, accepted });
+
+  const lateSubscriber = await connect();
+  sockets.push(lateSubscriber.socket);
+  lateSubscriber.socket.send(JSON.stringify([
+    "REQ", "late-subscription", { kinds: [23456], since: event.created_at, "#x": [topic] },
+  ]));
+  const retained = await lateSubscriber.next((message) =>
+    message[0] === "EVENT" && message[1] === "late-subscription");
+  await lateSubscriber.next((message) => message[0] === "EOSE" && message[1] === "late-subscription");
+  expect(retained[2]?.id === event.id, "late subscriber did not receive retained discovery", retained);
+
+  const tampered = { ...event, content: "tampered" };
+  publisher.socket.send(JSON.stringify(["EVENT", tampered]));
+  const rejected = await publisher.next((message) => message[0] === "OK" && message[2] === false);
+  expect(rejected[3]?.startsWith("invalid:"), "tampered event was not rejected", rejected);
+
+  const denied = await new Promise((resolveDenied) => {
+    const socket = new WebSocket(socketUrl, { headers: { Origin: "https://attacker.example" } });
+    socket.once("unexpected-response", (_, response) => resolveDenied(response.statusCode));
+    socket.once("open", () => resolveDenied(101));
+    socket.once("error", () => {});
+  });
+  expect(denied === 403, "unapproved browser origin reached the relay", denied);
+
+  console.log(JSON.stringify({
+    ok: true,
+    path: "cloudflare-trystero-relay",
+    health,
+    validEventAccepted: true,
+    retainedLateJoin: true,
+    invalidEventRejected: true,
+    originGate: true,
+  }));
+} finally {
+  for (const socket of sockets) socket.close();
+  child.kill("SIGTERM");
+  await new Promise((resolveExit) => {
+    if (child.exitCode != null) resolveExit();
+    else child.once("exit", resolveExit);
+    setTimeout(resolveExit, 5000);
+  });
+}

--- a/WebAssembly/harness/webrtc-udp-endpoint.mjs
+++ b/WebAssembly/harness/webrtc-udp-endpoint.mjs
@@ -5,11 +5,11 @@ const FRAME_HEADER_BYTES = 16;
 const BROADCAST_IP = 0xffffffff;
 const MAX_BUFFERED_BYTES = 1024 * 1024;
 const MAX_ROOM_PEERS = 8;
-const DEFAULT_RELAY_REDUNDANCY = 8;
 const TRYSTERO_APP_ID = "project-new-shoes-lan-v1";
 const TRANSPORT_VERSION = 1;
 const DATA_CHANNEL_LABEL = "cnc-udp-v1";
 const DATA_CHANNEL_PROTOCOL = "cnc-generals-udp-v1";
+const PROJECT_NOSTR_RELAY = "wss://relay.newshoes.gg/nostr";
 function normalizedBytes(value) {
   if (value instanceof Uint8Array) return value;
   if (value instanceof ArrayBuffer) return new Uint8Array(value);
@@ -148,13 +148,13 @@ export class WebRtcUdpEndpoint {
     this.displayName = cleanLabel(displayName, this.requestedPeerId);
     this.localIp = virtualIpForTrysteroPeer(selfId);
     this.iceServers = Array.isArray(iceServers) ? iceServers : [];
-    // Let Trystero maintain the production relay pool. Pinning five public
-    // endpoints made discovery fail as those services changed policy or went
-    // offline. Explicit relayUrls remain available for deterministic tests or
-    // self-hosting; otherwise connect redundantly to Trystero's current pool.
+    // Production discovery is project-owned so late joins do not depend on an
+    // arbitrary public Nostr pool. Explicit URLs remain available to tests and
+    // private deployments without changing the shipping endpoint.
     this.relayUrls = relayUrls
       ? [...new Set(relayUrls.map((url) => String(url).trim()))]
-      : null;
+      : [PROJECT_NOSTR_RELAY];
+    this.relaySource = relayUrls ? "configured" : "project";
     this.onDatagram = onDatagram;
     this.onStateChange = onStateChange;
     this.onDiagnostic = onDiagnostic;
@@ -204,6 +204,7 @@ export class WebRtcUdpEndpoint {
       discoveryStrategy: "trystero-nostr",
       productionTransport: true,
       relayTransport: false,
+      projectRelay: PROJECT_NOSTR_RELAY,
       enabled: !this.closed,
       connected: this.discoveryConnected || openPeers > 0,
       signalingConnected: this.discoveryConnected,
@@ -397,9 +398,7 @@ export class WebRtcUdpEndpoint {
   async connect(timeoutMs = 20000) {
     if (this.discoveryRoom) return this.snapshot();
     this.closed = false;
-    const relayConfig = this.relayUrls
-      ? { urls: this.relayUrls }
-      : { redundancy: DEFAULT_RELAY_REDUNDANCY };
+    const relayConfig = { urls: this.relayUrls, redundancy: this.relayUrls.length };
     this.discoveryRoom = joinRoom({
       appId: TRYSTERO_APP_ID,
       relayConfig,
@@ -418,8 +417,8 @@ export class WebRtcUdpEndpoint {
     this.discoveryRoom.onPeerJoin = (peerId) => this.addPeer(peerId);
     this.discoveryRoom.onPeerLeave = (peerId) => this.removePeer(peerId);
     this.emitDiagnostic({ kind: "event", type: "discovery.connect", detail: {
-      relayCount: this.relayUrls?.length ?? DEFAULT_RELAY_REDUNDANCY,
-      relaySource: this.relayUrls ? "configured" : "trystero-defaults",
+      relayCount: this.relayUrls.length,
+      relaySource: this.relaySource,
       iceServerCount: this.iceServers.length,
     } });
     return this.waitForDiscoveryRelay(timeoutMs);

--- a/WebAssembly/package-lock.json
+++ b/WebAssembly/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "name": "project-new-shoes",
       "devDependencies": {
+        "@noble/secp256k1": "3.1.0",
         "esbuild": "0.28.1",
         "playwright": "1.61.0",
         "trystero": "0.25.2",

--- a/WebAssembly/package.json
+++ b/WebAssembly/package.json
@@ -191,6 +191,7 @@
     "test:browser-network-two-contexts": "npm run build:wasm && node harness/network_two_contexts_smoke.mjs",
     "test:browser-network-websocket-transport": "npm run build:wasm && node harness/network_websocket_transport_smoke.mjs",
     "test:browser-network-websocket-live-transport": "npm run build:wasm && node harness/network_websocket_live_transport_smoke.mjs",
+    "test:trystero-relay": "node harness/trystero_relay_worker_smoke.mjs",
     "test:browser-network-webrtc-transport": "npm run build:port && node harness/network_webrtc_live_transport_smoke.mjs",
     "test:browser-network-webrtc-late-join": "npm run build:port && CNC_LATE_JOIN_DELAY_MS=12000 node harness/network_webrtc_live_transport_smoke.mjs",
     "test:browser-lan-webrtc-playable-match": "npm run build:port && node harness/lan_webrtc_playable_match_smoke.mjs",
@@ -229,6 +230,7 @@
     "verify:bink-loadscore-movie-frontier:strict": "node tools/verify_bink_loadscore_movie_frontier.mjs"
   },
   "devDependencies": {
+    "@noble/secp256k1": "3.1.0",
     "esbuild": "0.28.1",
     "playwright": "1.61.0",
     "trystero": "0.25.2",


### PR DESCRIPTION
Adds a project-owned Nostr relay on a hibernating Cloudflare Durable Object and configures multiplayer discovery to use `wss://relay.newshoes.gg/nostr`. Game traffic remains peer-to-peer over WebRTC.

The local Worker gate covers signed routing, retained late joins, tamper rejection, and Origin filtering. Two Chromium clients also discovered each other through the Worker and exchanged an original-engine datagram with zero gameplay bytes passing through discovery. Wrangler production bundling passes.

Production deployment still needs the `cloudflare-relay` GitHub environment and a scoped Cloudflare token, so this keeps issue #20 open.

Agent-Model: OpenAI gpt-5.6-sol