### PR TITLE
Disable automatic P2P startup

### DIFF
--- a/WebAssembly/harness/multiplayer_launch_policy.mjs
+++ b/WebAssembly/harness/multiplayer_launch_policy.mjs
@@ -1,0 +1,8 @@
+// Emergency release policy: multiplayer discovery must never delay or prevent
+// the game from launching. Keep automatic P2P disabled until the production
+// relay is deployed and independently health-checked.
+export const P2P_AUTO_CONNECT_ENABLED = false;
+
+export function shouldAutoConnectP2p(room) {
+  return P2P_AUTO_CONNECT_ENABLED && String(room ?? "").trim().length > 0;
+}

--- a/WebAssembly/harness/multiplayer_launch_policy_unit.mjs
+++ b/WebAssembly/harness/multiplayer_launch_policy_unit.mjs
@@ -1,0 +1,13 @@
+import assert from "node:assert/strict";
+import {
+  P2P_AUTO_CONNECT_ENABLED,
+  shouldAutoConnectP2p,
+} from "./multiplayer_launch_policy.mjs";
+
+assert.equal(P2P_AUTO_CONNECT_ENABLED, false);
+assert.equal(shouldAutoConnectP2p("default-room"), false,
+  "the default room must not start P2P discovery during game launch");
+assert.equal(shouldAutoConnectP2p("private-room"), false,
+  "an explicitly entered room must not block launch while P2P is disabled");
+
+console.log("multiplayer launch policy unit passed");

--- a/WebAssembly/harness/play.mjs
+++ b/WebAssembly/harness/play.mjs
@@ -18,6 +18,7 @@ import {
   normalizeCommanderName,
   saveNetworkSettings as persistNetworkSettings,
 } from "./multiplayer_identity.mjs";
+import { shouldAutoConnectP2p } from "./multiplayer_launch_policy.mjs";
 
 const analytics = window.ZeroHAnalytics;
 const track = (name, params) => analytics?.track(name, params);
@@ -802,7 +803,7 @@ async function start() {
     const networkSettings = networkSettingsFromInputs();
     saveNetworkSettings(networkSettings);
     let networkRuntime = null;
-    if (networkSettings.room) {
+    if (shouldAutoConnectP2p(networkSettings.room)) {
       report(`joining P2P room ${networkSettings.room}...`);
       if (networkStatusNode) networkStatusNode.textContent = "Discovering peers and connecting WebRTC ICE...";
       const iceServers = networkSettings.iceServerUrl
@@ -828,7 +829,9 @@ async function start() {
         networkStatusNode.textContent = `Joined ${networkSettings.room} as ${networkRuntime.endpoint.displayName} (${ipText}). Open Multiplayer → LAN.`;
       }
     } else if (networkStatusNode) {
-      networkStatusNode.textContent = "Offline. Enter a shared room to enable WebRTC multiplayer.";
+      networkStatusNode.textContent = networkSettings.room
+        ? "P2P multiplayer is temporarily disabled. Starting offline."
+        : "Offline. P2P multiplayer is temporarily disabled.";
     }
     const startAudioRuntime = await rpc("resumeBrowserAudioRuntime", {
       trigger: "play.start",

--- a/WebAssembly/package.json
+++ b/WebAssembly/package.json
@@ -89,6 +89,7 @@
     "probe:p2-opfs": "node harness/p2_opfs_probe.mjs",
     "test:issue-recorder": "node harness/issue_recorder_unit.mjs && node harness/network_diagnostics_unit.mjs && node harness/issue_dump_network_decode_smoke.mjs && node harness/issue_dump_upload_smoke.mjs && node harness/issue_recorder_ui_smoke.mjs",
     "test:multiplayer-identity": "node harness/multiplayer_identity_unit.mjs",
+    "test:multiplayer-launch-policy": "node harness/multiplayer_launch_policy_unit.mjs",
     "test:startup-vertical": "npm run build:startup-vertical && node tools/run_startup_vertical_smoke.mjs",
     "test:startup-vertical-browser": "npm run build:port && node harness/startup_vertical_smoke.mjs",
     "test:real-shellmap": "npm run build:port && node harness/shellmap_real_init_gate.mjs",

--- a/WebAssembly/tools/check_pages_sources.mjs
+++ b/WebAssembly/tools/check_pages_sources.mjs
@@ -32,6 +32,7 @@ const scripts = [
   "harness/launcher-retail-presentation.mjs",
   "harness/launcher.js",
   "harness/multiplayer_identity.mjs",
+  "harness/multiplayer_launch_policy.mjs",
   "harness/network-diagnostics.mjs",
   "harness/opfs_realm_files.mjs",
   "harness/pages_deployment_smoke.mjs",

--- a/WebAssembly/tools/pages_site_manifest.mjs
+++ b/WebAssembly/tools/pages_site_manifest.mjs
@@ -43,6 +43,7 @@ export const PAGES_HARNESS_FILES = Object.freeze([
   "launcher.js",
   "manifest.webmanifest",
   "multiplayer_identity.mjs",
+  "multiplayer_launch_policy.mjs",
   "network-diagnostics.mjs",
   "opfs_realm_files.mjs",
   "play.mjs",


### PR DESCRIPTION
Emergency mitigation for #22.\n\nAutomatic Trystero discovery is disabled while the production relay is unavailable. The default room no longer starts a relay connection, so game startup proceeds immediately in offline mode with an explicit status message. The transport implementation remains intact for re-enablement after deployment and health verification.\n\nValidation:\n- Multiplayer launch-policy regression test\n- Pages source/package check\n- `play.mjs` syntax check\n\nAgent-Model: OpenAI GPT-5