### PR TITLE
Make P2P registration non-blocking

### DIFF
--- a/WebAssembly/harness/multiplayer_launch_policy.mjs
+++ b/WebAssembly/harness/multiplayer_launch_policy.mjs
@@ -1,8 +1,83 @@
-// Emergency release policy: multiplayer discovery must never delay or prevent
-// the game from launching. Keep automatic P2P disabled until the production
-// relay is deployed and independently health-checked.
-export const P2P_AUTO_CONNECT_ENABLED = false;
+// Multiplayer discovery is best-effort. Registration runs beside game startup
+// and must always settle as a result object instead of rejecting into launch.
+export const P2P_AUTO_CONNECT_ENABLED = true;
+export const P2P_REGISTRATION_TIMEOUT_MS = 20_000;
 
 export function shouldAutoConnectP2p(room) {
   return P2P_AUTO_CONNECT_ENABLED && String(room ?? "").trim().length > 0;
+}
+
+function errorText(value, fallback) {
+  if (value instanceof Error && value.message) return value.message;
+  if (typeof value === "string" && value) return value;
+  return fallback;
+}
+
+function beginEndpointCleanup(rpc) {
+  void Promise.resolve()
+    .then(() => rpc("browserWebRtcEndpointDisconnect", {}))
+    .catch(() => {});
+}
+
+export async function registerP2pBestEffort({
+  rpc,
+  room,
+  peerId = null,
+  displayName = null,
+  iceServers = [],
+  timeoutMs = P2P_REGISTRATION_TIMEOUT_MS,
+}) {
+  if (!shouldAutoConnectP2p(room)) {
+    return { ok: false, skipped: true, error: null, runtime: null, cleanupStarted: false };
+  }
+  const boundedTimeoutMs = Number.isFinite(timeoutMs) && timeoutMs > 0
+    ? Math.floor(timeoutMs)
+    : P2P_REGISTRATION_TIMEOUT_MS;
+  let timeoutId = null;
+  const timeout = new Promise((resolve) => {
+    timeoutId = setTimeout(() => resolve({
+      ok: false,
+      error: `P2P discovery timed out after ${boundedTimeoutMs}ms`,
+    }), boundedTimeoutMs);
+  });
+  try {
+    const result = await Promise.race([
+      Promise.resolve().then(() => rpc("browserWebRtcEndpointConnect", {
+        room: String(room).trim(),
+        peerId,
+        displayName,
+        iceServers,
+        timeoutMs: boundedTimeoutMs,
+      })),
+      timeout,
+    ]);
+    if (result?.ok === true) {
+      return {
+        ok: true,
+        skipped: false,
+        error: null,
+        runtime: result.runtime ?? null,
+        cleanupStarted: false,
+      };
+    }
+    beginEndpointCleanup(rpc);
+    return {
+      ok: false,
+      skipped: false,
+      error: errorText(result?.error, "P2P room registration failed"),
+      runtime: result?.runtime ?? null,
+      cleanupStarted: true,
+    };
+  } catch (error) {
+    beginEndpointCleanup(rpc);
+    return {
+      ok: false,
+      skipped: false,
+      error: errorText(error, "P2P room registration failed"),
+      runtime: null,
+      cleanupStarted: true,
+    };
+  } finally {
+    if (timeoutId !== null) clearTimeout(timeoutId);
+  }
 }

--- a/WebAssembly/harness/multiplayer_launch_policy_unit.mjs
+++ b/WebAssembly/harness/multiplayer_launch_policy_unit.mjs
@@ -1,13 +1,93 @@
 import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
 import {
   P2P_AUTO_CONNECT_ENABLED,
+  registerP2pBestEffort,
   shouldAutoConnectP2p,
 } from "./multiplayer_launch_policy.mjs";
 
-assert.equal(P2P_AUTO_CONNECT_ENABLED, false);
-assert.equal(shouldAutoConnectP2p("default-room"), false,
-  "the default room must not start P2P discovery during game launch");
-assert.equal(shouldAutoConnectP2p("private-room"), false,
-  "an explicitly entered room must not block launch while P2P is disabled");
+assert.equal(P2P_AUTO_CONNECT_ENABLED, true);
+assert.equal(shouldAutoConnectP2p("default-room"), true);
+assert.equal(shouldAutoConnectP2p(""), false);
+
+const successCalls = [];
+const success = await registerP2pBestEffort({
+  rpc: async (command, payload) => {
+    successCalls.push({ command, payload });
+    return { ok: true, runtime: { endpoint: { localIp: 0x0a000001 } } };
+  },
+  room: "default-room",
+  peerId: "GeneralTest",
+  displayName: "GeneralTest",
+});
+assert.equal(success.ok, true);
+assert.equal(successCalls.length, 1);
+assert.equal(successCalls[0].command, "browserWebRtcEndpointConnect");
+assert.equal(successCalls[0].payload.room, "default-room");
+
+const failureCalls = [];
+const failure = await registerP2pBestEffort({
+  rpc: async (command) => {
+    failureCalls.push(command);
+    return command === "browserWebRtcEndpointConnect"
+      ? { ok: false, error: "relay unavailable", runtime: { enabled: true } }
+      : { ok: true };
+  },
+  room: "default-room",
+});
+await Promise.resolve();
+assert.deepEqual(failureCalls, [
+  "browserWebRtcEndpointConnect",
+  "browserWebRtcEndpointDisconnect",
+]);
+assert.deepEqual(failure, {
+  ok: false,
+  skipped: false,
+  error: "relay unavailable",
+  runtime: { enabled: true },
+  cleanupStarted: true,
+});
+
+const rejectionCalls = [];
+const rejection = await registerP2pBestEffort({
+  rpc: async (command) => {
+    rejectionCalls.push(command);
+    if (command === "browserWebRtcEndpointConnect") throw new Error("registration rejected");
+    return { ok: true };
+  },
+  room: "default-room",
+});
+await Promise.resolve();
+assert.equal(rejection.ok, false);
+assert.equal(rejection.error, "registration rejected");
+assert.deepEqual(rejectionCalls, [
+  "browserWebRtcEndpointConnect",
+  "browserWebRtcEndpointDisconnect",
+]);
+
+const timeoutCalls = [];
+const timeoutAttempt = registerP2pBestEffort({
+  rpc: (command) => {
+    timeoutCalls.push(command);
+    if (command === "browserWebRtcEndpointConnect") return new Promise(() => {});
+    return Promise.resolve({ ok: true });
+  },
+  room: "default-room",
+  timeoutMs: 10,
+});
+const timedOut = await timeoutAttempt;
+await Promise.resolve();
+assert.equal(timedOut.ok, false);
+assert.match(timedOut.error, /timed out after 10ms/);
+assert.deepEqual(timeoutCalls, [
+  "browserWebRtcEndpointConnect",
+  "browserWebRtcEndpointDisconnect",
+]);
+
+const playSource = await readFile(new URL("./play.mjs", import.meta.url), "utf8");
+assert.match(playSource, /void registerP2pBestEffort\(/,
+  "game startup must launch P2P registration without awaiting it");
+assert.doesNotMatch(playSource, /await registerP2pBestEffort\(/,
+  "game startup must never await P2P registration");
 
 console.log("multiplayer launch policy unit passed");

--- a/WebAssembly/harness/play.mjs
+++ b/WebAssembly/harness/play.mjs
@@ -18,7 +18,10 @@ import {
   normalizeCommanderName,
   saveNetworkSettings as persistNetworkSettings,
 } from "./multiplayer_identity.mjs";
-import { shouldAutoConnectP2p } from "./multiplayer_launch_policy.mjs";
+import {
+  registerP2pBestEffort,
+  shouldAutoConnectP2p,
+} from "./multiplayer_launch_policy.mjs";
 
 const analytics = window.ZeroHAnalytics;
 const track = (name, params) => analytics?.track(name, params);
@@ -804,8 +807,10 @@ async function start() {
     saveNetworkSettings(networkSettings);
     let networkRuntime = null;
     if (shouldAutoConnectP2p(networkSettings.room)) {
-      report(`joining P2P room ${networkSettings.room}...`);
-      if (networkStatusNode) networkStatusNode.textContent = "Discovering peers and connecting WebRTC ICE...";
+      networkRuntime = { status: "registering", room: networkSettings.room };
+      if (networkStatusNode) {
+        networkStatusNode.textContent = "Discovering peers in the background; game launch will continue offline until connected.";
+      }
       const iceServers = networkSettings.iceServerUrl
         ? [{
           urls: networkSettings.iceServerUrl.split(",").map((entry) => entry.trim()).filter(Boolean),
@@ -813,25 +818,43 @@ async function start() {
           ...(networkSettings.iceCredential ? { credential: networkSettings.iceCredential } : {}),
         }]
         : [];
-      const networkConnect = await rpc("browserWebRtcEndpointConnect", {
+      void registerP2pBestEffort({
+        rpc,
         room: networkSettings.room,
         peerId: networkSettings.name || null,
         displayName: networkSettings.name || null,
         iceServers,
+      }).then((registration) => {
+        if (registration.ok) {
+          networkRuntime = registration.runtime;
+          const endpoint = networkRuntime?.endpoint;
+          const virtualIp = endpoint?.localIp >>> 0;
+          const ipText = [24, 16, 8, 0]
+            .map((shift) => (virtualIp >>> shift) & 0xff).join(".");
+          if (networkStatusNode) {
+            networkStatusNode.textContent = `Joined ${networkSettings.room} as ${endpoint?.displayName ?? networkSettings.name} (${ipText}). Open Multiplayer → LAN.`;
+            networkStatusNode.removeAttribute("title");
+          }
+          track("p2p_discovery", { result: "connected" });
+        } else {
+          networkRuntime = {
+            status: "offline",
+            room: networkSettings.room,
+            error: registration.error,
+          };
+          if (networkStatusNode) {
+            networkStatusNode.textContent = "P2P unavailable. Game is running offline.";
+            networkStatusNode.title = registration.error ?? "P2P registration did not complete";
+          }
+          console.warn("[play] P2P registration failed; continuing offline", registration.error);
+          track("p2p_discovery", { result: "offline" });
+        }
+        issueRecorder.setSessionContext({ network: networkRuntime });
+      }).catch((error) => {
+        console.warn("[play] P2P registration status update failed; continuing offline", error);
       });
-      if (networkConnect?.ok !== true) {
-        throw new Error(networkConnect?.error ?? "P2P room connection failed");
-      }
-      networkRuntime = networkConnect.runtime;
-      const virtualIp = networkRuntime?.endpoint?.localIp >>> 0;
-      const ipText = [24, 16, 8, 0].map((shift) => (virtualIp >>> shift) & 0xff).join(".");
-      if (networkStatusNode) {
-        networkStatusNode.textContent = `Joined ${networkSettings.room} as ${networkRuntime.endpoint.displayName} (${ipText}). Open Multiplayer → LAN.`;
-      }
     } else if (networkStatusNode) {
-      networkStatusNode.textContent = networkSettings.room
-        ? "P2P multiplayer is temporarily disabled. Starting offline."
-        : "Offline. P2P multiplayer is temporarily disabled.";
+      networkStatusNode.textContent = "Offline. Enter a shared room to enable WebRTC multiplayer.";
     }
     const startAudioRuntime = await rpc("resumeBrowserAudioRuntime", {
       trigger: "play.start",


### PR DESCRIPTION
## Summary

- re-enable automatic Trystero discovery through the deployed Cloudflare relay
- start registration in the background so game boot never waits on P2P
- fall back to offline play on failed, rejected, or hung registration
- bound registration with a 20-second cleanup timeout
- cover success, failure, rejection, timeout, and launcher non-await behavior

## Verification

- npm run test:multiplayer-launch-policy
- npm run test:multiplayer-identity
- npm run check:pages
- node --check harness/play.mjs
- node --check harness/multiplayer_launch_policy.mjs
- npm run build:port
- live two-browser transport test against wss://relay.newshoes.gg/nostr, including a 12-second late join and an original-engine packet

Closes #20

Agent-Model: OpenAI GPT-5