### PR TITLE
Fix camera-dependent water gaps

### DIFF
--- a/WebAssembly/harness/d3d8_executor.mjs
+++ b/WebAssembly/harness/d3d8_executor.mjs
@@ -226,6 +226,7 @@ let d3d8CurrentElementArrayBuffer = null;
 let d3d8TemporaryIndexBuffer = null;
 let d3d8TemporaryIndexBufferBytes = 0;
 let d3d8CurrentDepthMask = true;
+let d3d8CurrentColorMask = [true, true, true, true];
 let d3d8LastAppliedViewportKey = null;
 let d3d8CachedViewportInput = null;
 let d3d8CachedNormalizedViewport = null;
@@ -239,6 +240,17 @@ function setD3D8DepthMask(enabled) {
   if (d3d8CurrentDepthMask !== next) {
     gl.depthMask(next);
     d3d8CurrentDepthMask = next;
+  }
+}
+
+function setD3D8ColorMask(red, green, blue, alpha) {
+  if (!gl) {
+    return;
+  }
+  const next = [Boolean(red), Boolean(green), Boolean(blue), Boolean(alpha)];
+  if (d3d8CurrentColorMask.some((enabled, index) => enabled !== next[index])) {
+    gl.colorMask(next[0], next[1], next[2], next[3]);
+    d3d8CurrentColorMask = next;
   }
 }
 
@@ -6416,23 +6428,33 @@ function paintD3D8Clear(flags, red, green, blue, alpha, z, stencil) {
     }
     if (d3d8PerfCountersEnabled) d3d8PerfStats.clearSetupMs += perfNow() - setupStartedAt;
     if (clearBits !== 0) {
-      // D3D8's Clear ignores the depth/stencil write masks, but WebGL's
-      // gl.clear RESPECTS gl.depthMask: if a prior draw left depth writes
-      // disabled (e.g. a transparent/UI pass with ZWRITE off), the depth clear
-      // is silently skipped, leaving a stale depth buffer that later geometry
-      // (the terrain) fails the depth test against — the whole map renders
-      // black. Force the depth write mask on for the clear, then restore it.
-      // (Stencil already forces stencilMask above before clearing stencil.)
+      // D3D8 Clear writes every component selected by its flags regardless of
+      // the draw write masks. WebGL clear obeys colorMask/depthMask/stencilMask.
+      // The terrain intentionally disables alpha writes after producing the
+      // soft-water shoreline mask, so failing to override colorMask here leaves
+      // stale screen-space alpha sectors that make water disappear as the
+      // camera moves. Force the affected masks on, then restore draw state.
+      const restoreColorMask = (clearBits & gl.COLOR_BUFFER_BIT) !== 0 &&
+        d3d8CurrentColorMask.some((enabled) => !enabled);
+      const previousColorMask = restoreColorMask ? d3d8CurrentColorMask : null;
       const depthMaskCheckStartedAt = perfNow();
       const restoreDepthMask =
         (clearBits & gl.DEPTH_BUFFER_BIT) !== 0 && !d3d8CurrentDepthMask;
       if (d3d8PerfCountersEnabled) d3d8PerfStats.clearDepthMaskCheckMs += perfNow() - depthMaskCheckStartedAt;
+      if (restoreColorMask) {
+        setD3D8ColorMask(true, true, true, true);
+      }
       if (restoreDepthMask) {
         const depthMaskToggleStartedAt = perfNow();
         setD3D8DepthMask(true);
         if (d3d8PerfCountersEnabled) d3d8PerfStats.clearDepthMaskToggleMs += perfNow() - depthMaskToggleStartedAt;
       }
       timedGlClear(clearBits);
+      if (previousColorMask) {
+        setD3D8ColorMask(
+          previousColorMask[0], previousColorMask[1],
+          previousColorMask[2], previousColorMask[3]);
+      }
       if (restoreDepthMask) {
         const depthMaskToggleStartedAt = perfNow();
         setD3D8DepthMask(false);
@@ -10917,7 +10939,7 @@ function applyD3D8RenderState(renderState, options = {}) {
   }
   if (d3d8RenderGlStateTupleChanged(
     "colorMask", colorMaskR, colorMaskG, colorMaskB, colorMaskA)) {
-    gl.colorMask(colorMaskR, colorMaskG, colorMaskB, colorMaskA);
+    setD3D8ColorMask(colorMaskR, colorMaskG, colorMaskB, colorMaskA);
   }
   setD3D8TrackedCapability(gl.STENCIL_TEST, "stencilEnabled", stencilEnabled);
   if (stencilEnabled) {
@@ -14019,6 +14041,7 @@ function paintD3D8DrawIndexed(payload = {}) {
     d3dColorToNormalizedRgba,
     d3dMaterialSourceName,
     paintCanvasRgba,
+    setD3D8ColorMask,
     setD3D8GammaRamp,
     onD3D8BackbufferResize,
     releaseD3D8ProbeBackingStore,

--- a/WebAssembly/harness/d3d8_offscreen_viewport_smoke.mjs
+++ b/WebAssembly/harness/d3d8_offscreen_viewport_smoke.mjs
@@ -32,7 +32,7 @@ try {
       throw new Error("WebGL2 context unavailable");
     }
 
-    const { hooks } = createD3D8Executor({
+    const { hooks, diag } = createD3D8Executor({
       canvas,
       gl,
       state: { graphics: {} },
@@ -75,6 +75,20 @@ try {
     }) === 1, "offscreen framebuffer bind failed");
 
     hooks.cncPortD3D8Clear(1, 255, 0, 0, 255, 1, 0);
+
+    // Terrain rendering leaves alpha writes disabled after drawing the
+    // destination-alpha shoreline mask. D3D8 Clear must still replace alpha;
+    // WebGL clear would preserve stale alpha unless the executor temporarily
+    // overrides and then restores the draw color mask.
+    diag.setD3D8ColorMask(true, true, true, false);
+    hooks.cncPortD3D8Clear(1, 12, 34, 56, 64, 1, 0);
+    const maskedClearPixel = readPixel(128, 128);
+    const restoredColorMask = Array.from(gl.getParameter(gl.COLOR_WRITEMASK));
+    expect(maskedClearPixel.join(",") === "12,34,56,64",
+      "D3D8 clear incorrectly obeyed the draw color mask", maskedClearPixel);
+    expect(restoredColorMask.join(",") === "true,true,true,false",
+      "D3D8 clear did not restore the draw color mask", restoredColorMask);
+    diag.setD3D8ColorMask(true, true, true, true);
     hooks.cncPortD3D8SetViewport({
       x: 0,
       y: 0,
@@ -149,6 +163,8 @@ try {
       renderTarget: [256, 256],
       offscreenViewport,
       offscreenScissor,
+      maskedClearPixel,
+      restoredColorMask,
       samples,
       restoredViewport,
       restoredScissor,


### PR DESCRIPTION
Fixes #24.

Standing water could disappear in rectangular screen-space sections as the camera moved. The water geometry was still submitted, but its blend factor came from stale destination-alpha shoreline data.

The D3D8 engine clears the offscreen scene target before rebuilding the shoreline mask. WebGL `gl.clear()` respects `colorMask`, while D3D8 `Clear` does not inherit the draw write mask. Terrain rendering leaves alpha writes disabled, so the bridge skipped the alpha clear and retained shoreline sectors from earlier camera positions.

This change tracks the applied WebGL color mask, temporarily enables all color channels for D3D8 color clears, and restores the previous draw mask afterward. The offscreen viewport browser test now covers the exact masked-clear behavior and verifies both the alpha result and mask restoration.

Validated with:

- `npm run test:d3d8-offscreen-viewport-browser`
- `npm run build:port`
- JavaScript syntax checks
- `git diff --check`

The focused browser pixel test and full port build pass. I could not replay Fortress Avalanche on a real GPU because the configured GPU hosts were unavailable, so this stays as a draft until that visual check is done.

Agent-Model: OpenAI gpt-5.6-sol