### PR TITLE
Close runtime when the original engine exits

### DIFF
--- a/WebAssembly/harness/bridge.js
+++ b/WebAssembly/harness/bridge.js
@@ -1099,6 +1099,15 @@ function createThreadedEngineController() {
           window.dispatchEvent(new CustomEvent("cncport:threadedlooperror", { detail: msg }));
         } catch (_error) { /* no DOM event support */ }
         return;
+      case "quitRequested":
+        threadedLog("original engine requested runtime exit", {
+          logicFrame: msg.logicFrame ?? null,
+          clientFrame: msg.clientFrame ?? null,
+        });
+        try {
+          window.dispatchEvent(new CustomEvent("cncport:runtimequit", { detail: msg }));
+        } catch (_error) { /* no DOM event support */ }
+        return;
       case "tickError":
         threadedLog("engine tick error", { error: msg.error });
         return;

--- a/WebAssembly/harness/engine_realm_boot.mjs
+++ b/WebAssembly/harness/engine_realm_boot.mjs
@@ -699,6 +699,7 @@ export default async function setupEngineRealm({ canvas, Module, realm, options 
     engineFrameTimes: [], // rolling real-engine update durations (ms)
     presentationFrameTimes: [], // rolling intervals between presented client frames (ms)
     pacingSamples: [], // last ~900 {t, logic} for pacing-evenness probes
+    quitRequested: false,
   };
   let framePacedFn = null;
 
@@ -733,6 +734,7 @@ export default async function setupEngineRealm({ canvas, Module, realm, options 
     loop.engineFrameTimes.length = 0;
     loop.presentationFrameTimes.length = 0;
     loop.pacingSamples.length = 0;
+    loop.quitRequested = false;
     respond({ cmd: "startLoopResult", id: msg.id, ok: true, pacing, clientFps, logicFps });
   }
 
@@ -781,6 +783,9 @@ export default async function setupEngineRealm({ canvas, Module, realm, options 
         for (let i = 0; i < logicToRun; i += 1) {
           result = parseMaybeJson(framePacedFn(1));
           loop.logicFrames += 1;
+          if (result?.quitting === true) {
+            break;
+          }
         }
       }
     } catch (error) {
@@ -817,6 +822,21 @@ export default async function setupEngineRealm({ canvas, Module, realm, options 
     if (loop.pacingSamples.length > 900) {
       loop.pacingSamples.splice(0, loop.pacingSamples.length - 900);
     }
+    if (result.quitting === true) {
+      loop.active = false;
+      if (!loop.quitRequested) {
+        loop.quitRequested = true;
+        recordLog("original engine requested runtime exit", {
+          logicFrame: result.logicFrame,
+          clientFrame: result.clientFrame,
+        });
+        postToMain({
+          cmd: "quitRequested",
+          logicFrame: result.logicFrame,
+          clientFrame: result.clientFrame,
+        });
+      }
+    }
   }
 
   // ---- periodic status --------------------------------------------------------
@@ -848,6 +868,7 @@ export default async function setupEngineRealm({ canvas, Module, realm, options 
         startedAt: loop.startedAt,
         clientFrames: loop.clientFrames,
         logicFrames: loop.logicFrames,
+        quitRequested: loop.quitRequested,
       },
       timing: {
         engineFrameMs: loop.engineFrameTimes.slice(),

--- a/WebAssembly/harness/play.mjs
+++ b/WebAssembly/harness/play.mjs
@@ -1182,6 +1182,11 @@ window.ZeroHRuntime = {
   get closing() { return runtimeClosing; },
 };
 
+window.addEventListener("cncport:runtimequit", () => {
+  if (!runtimeStarted || runtimeClosing || runtimeClosed) return;
+  void exitToDesktop();
+});
+
 window.addEventListener("keydown", (event) => {
   if (!gameRunning || !event.ctrlKey || !event.altKey || event.key !== "Escape") return;
   event.preventDefault();

--- a/WebAssembly/harness/threaded_play_gate.mjs
+++ b/WebAssembly/harness/threaded_play_gate.mjs
@@ -1015,13 +1015,26 @@ async function main() {
         "/home/web_user/Command and Conquer Generals Zero Hour Data/Save/__threaded_gate_roundtrip.sav",
       )),
     }));
+    const originalExitClick = await page.evaluate(() =>
+      window.CnCPort.rpc("clickWindowByName", { name: "MainMenu.wnd:ButtonExit" }));
+    await page.waitForFunction(() =>
+      window.ZeroHRuntime?.closing === true || window.ZeroHRuntime?.closed === true, null, {
+      timeout: 30000,
+      polling: 100,
+    });
     const relaunchExit = await page.evaluate(() => window.ZeroHRuntime.exit());
-    summary.cleanExit.relaunch = { state: relaunchState, exit: relaunchExit };
+    summary.cleanExit.relaunch = {
+      state: relaunchState,
+      originalExitClick,
+      exit: relaunchExit,
+    };
     checks.push([
-      "desktop shortcut transparently relaunches and cleanly closes a fresh runtime",
+      "desktop shortcut relaunches and the original Exit button cleanly closes the fresh runtime",
       relaunchState.started === true
         && relaunchState.closed === false
         && JSON.stringify(relaunchState.saveBytes) === JSON.stringify([0x53, 0x41, 0x56, 0x45, 0x21])
+        && originalExitClick?.ok === true
+        && originalExitClick?.result?.clicked === true
         && relaunchExit?.ok === true
         && relaunchExit?.result?.engine?.workerTerminated === true
         && relaunchExit?.result?.engine?.pendingCommands === 0

--- a/WebAssembly/src/wasm_real_engine_init.cpp
+++ b/WebAssembly/src/wasm_real_engine_init.cpp
@@ -5449,6 +5449,13 @@ void run_real_engine_frames(int frame_count)
 	reset_frame_texture_diagnostics();
 	if (g_state.attempted && g_state.init_returned && TheGameEngine != NULL) {
 		for (int frame = 0; frame < frame_count; ++frame) {
+			// GameEngine::execute() owns the native lifetime contract: once an
+			// original UI callback sets m_quitting, it returns without another
+			// update. The browser drives update() one frame at a time, so preserve
+			// that guard here instead of drawing an empty post-quit world forever.
+			if (TheGameEngine->getQuitting() != FALSE) {
+				break;
+			}
 			++g_frame_state.frames_attempted;
 			const double frame_started_at = emscripten_get_now();
 			reset_engine_frame_profile();


### PR DESCRIPTION
## Summary

- preserve the original `GameEngine::execute()` quit guard in browser-stepped frames
- stop the threaded paced loop and forward an original-engine quit request to the launcher
- reuse the launcher's durable save, worker, canvas, audio, network, and OPFS teardown
- extend the threaded browser gate to click the original main-menu Exit button, verify complete teardown, and relaunch from the desktop shortcut

## Root cause

The original Exit callbacks set `GameEngine::m_quitting`. Native execution stops because `GameEngine::execute()` owns a `while (!m_quitting)` loop, but the browser drives the engine one frame at a time and bypassed that loop. It therefore kept calling `update()` after the UI/game state had been cleared, leaving an empty terrain canvas alive. The worker published the quitting bit in status but never notified the launcher.

## User impact

Choosing Exit now enters the same bounded shutdown sequence as the launcher close path: save scheduling and frames stop, a fresh final save is persisted, the engine worker is terminated, and the transferred canvas is removed. The desktop shortcut can then start a fresh runtime without a page refresh.

## Verification

- `node --check harness/bridge.js harness/engine_realm_boot.mjs harness/play.mjs harness/threaded_play_gate.mjs`
- `git diff --check`
- `npm run verify:runtime-shutdown-order`
- `npm run verify:save-persistence-order`
- `npm run build:port`
- `npm run verify:threaded-play`: shutdown-order checks passed and both threaded debug/release builds linked 1312/1312; the browser leg could not boot because this worktree has no retail `INIZH.big` archive (404)
- real-GPU verification remains pending because the configured GPU host is unreachable from this machine

Closes #29

Agent-Model: OpenAI gpt-5.6-sol