### PR TITLE
Fix terrain scorch depth flicker

### DIFF
--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/BaseHeightMap.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/BaseHeightMap.cpp
@@ -216,7 +216,11 @@ void BaseHeightMapRenderObjClass::drawScorches(void)
 
 	DX8Wrapper::Set_Texture(0,m_scorchTexture);
 	if (Is_Hidden() == 0) {
+		// The small vertex lift can collapse onto the terrain at distant camera depths.
+		const UnsignedInt previousZBias = DX8Wrapper::Get_DX8_Render_State(D3DRS_ZBIAS);
+		DX8Wrapper::Set_DX8_Render_State(D3DRS_ZBIAS, 1);
 		DX8Wrapper::Draw_Triangles(	0,m_curNumScorchIndices/3, 0,	m_curNumScorchVertices);
+		DX8Wrapper::Set_DX8_Render_State(D3DRS_ZBIAS, previousZBias);
 	}
 }
 #endif

--- a/WebAssembly/harness/skirmish_start_smoke.mjs
+++ b/WebAssembly/harness/skirmish_start_smoke.mjs
@@ -79,6 +79,7 @@ const musicStopMaxFrames = parsePositiveInt("SKIRMISH_START_MUSIC_STOP_MAX_FRAME
 const requestedSkirmishMap = String(process.env.SKIRMISH_START_MAP ?? "").trim();
 const captureD3D8History = process.env.SKIRMISH_START_CAPTURE_D3D8_HISTORY === "1";
 const expectLightPulseProbe = process.env.SKIRMISH_START_LIGHT_PULSE_PROBE === "1";
+const expectScorchProbe = process.env.SKIRMISH_START_SCORCH_PROBE === "1";
 const distDir = parseDistDir();
 
 function parsePositiveInt(name, fallback) {
@@ -1031,6 +1032,59 @@ async function driveDecalProbe(page) {
   return info;
 }
 
+async function driveScorchProbe(page) {
+  const screenshot = resolve(screenshotsRoot, "scorch-depth-bias.png");
+  const reveal = await rpc(page, "revealLocalMap", { permanent: true });
+  expect(reveal?.ok === true, "scorch probe could not reveal the local map", reveal);
+  await runFrames(page, 2, "scorch reveal settle");
+
+  const drawables = await rpc(page, "queryDrawables");
+  const target = (drawables?.result?.drawables ?? []).find((drawable) =>
+    drawable.localOwned === true && drawable.onScreen === true &&
+    drawable.hidden !== true && drawable.worldPos);
+  expect(Boolean(target), "scorch probe could not find a visible local target", drawables?.result);
+
+  const position = {
+    x: Number(target.worldPos.x) + 40,
+    y: Number(target.worldPos.y) + 40,
+    z: Number(target.worldPos.z),
+  };
+  const trigger = await rpc(page, "realEngineDoFX", {
+    name: "WeaponFX_BattleshipTargetExplode",
+    useViewPosition: false,
+    clampToTerrain: true,
+    ...position,
+  });
+  expect(trigger?.ok === true, "scorch probe could not trigger the shipped explosion FX", trigger);
+
+  await page.evaluate(() => {
+    window.__cncSetD3D8SceneDrawHistoryLimit?.(4096);
+    window.__cncSetDiagLevel?.("full");
+  });
+  const frame = await rpc(page, "realEngineFrameSummary", { frames: 1 });
+  const labels = new Map(
+    (locateNested(frame?.frame, ["textureDiagnostics"])?.labels ?? [])
+      .map((label) => [Number(label.id), label.name || label.path || ""]),
+  );
+  const scorchDraws = (frame?.state?.graphics?.d3d8SceneDrawHistory ?? [])
+    .map((draw) => ({
+      sequence: draw.drawSequence,
+      texture: labels.get(Number(draw.texture0?.id ?? 0)) ?? "",
+      zBias: Number(draw.renderState?.zBias ?? 0),
+      polygonOffset: draw.appliedRenderState?.depth?.bias?.polygonOffset ?? null,
+    }))
+    .filter((draw) => /scorch/i.test(draw.texture));
+  await page.locator("#viewport").screenshot({ path: screenshot });
+  await page.evaluate(() => window.__cncSetDiagLevel?.("lite"));
+
+  expect(scorchDraws.length > 0,
+    "shipped explosion FX did not reach the terrain scorch draw", { trigger, scorchDraws });
+  expect(scorchDraws.every((draw) =>
+    draw.zBias === 1 && draw.polygonOffset?.enabled === true),
+    "terrain scorch draw did not reach WebGL with D3D8 depth bias enabled", scorchDraws);
+  return { target: target.name, position, trigger: trigger.result, scorchDraws, screenshot };
+}
+
 // Tree-lighting discriminator: read the baked per-vertex diffuse of the tree
 // draw pass (FVF XYZ|NORMAL|DIFFUSE|TEX1 = 0x152, stride 36) from the draw
 // history. If diffuse is ~white the CPU bake is wrong (sun-direction/light data
@@ -1429,6 +1483,11 @@ async function main() {
       decalProbe = await driveDecalProbe(page);
       console.error("[skirmish-start] decalProbe:", JSON.stringify(decalProbe));
     }
+    let scorchProbe = null;
+    if (expectScorchProbe) {
+      scorchProbe = await driveScorchProbe(page);
+      console.error("[skirmish-start] scorchProbe:", JSON.stringify(scorchProbe));
+    }
     await page.locator("#viewport").screenshot({ path: screenshotPath });
     const renderProbe = await sampleViewportGrid(page);
     expect(renderProbe.ok === true,
@@ -1634,6 +1693,7 @@ async function main() {
       enemyAiActivity,
       escMenuResume,
       rallyProbe,
+      scorchProbe,
       lightPulseProbe,
       renderProbe,
       // ADD-ONLY HUD diagnostics: full control-bar / shell / startNewGame state

--- a/WebAssembly/package.json
+++ b/WebAssembly/package.json
@@ -102,6 +102,7 @@
     "verify:launcher-polish-browser": "node harness/launcher_polish_browser_smoke.mjs",
     "verify:audio-startup-activation": "node harness/audio_startup_activation_smoke.mjs",
     "test:real-fx-render": "npm run build:port && node harness/real_fx_render_smoke.mjs",
+    "test:real-scorch-render": "npm run build:port && SKIRMISH_START_SCORCH_PROBE=1 node harness/skirmish_start_smoke.mjs",
     "test:real-heat-distortion": "npm run build:port && REAL_FX_EXPECT_HEAT=1 node harness/real_fx_render_smoke.mjs",
     "test:real-laser-draw": "npm run build:port && node harness/real_laser_draw_smoke.mjs",
     "test:weapon-impact-fx": "npm run build:port && node harness/weapon_impact_fx_smoke.mjs",


### PR DESCRIPTION
Closes #30

## What changed

- bracket the real terrain scorch draw with `D3DRS_ZBIAS = 1`
- restore the caller's previous Z-bias immediately after the draw
- add an opt-in real-skirmish regression probe that fires a shipped explosion FX, captures the gameplay frame, and checks the WebGL draw state

## Root cause

Explosion scorch vertices are tessellated directly over the height map and lifted by only `MAP_HEIGHT_SCALE / 10` (0.0625 world units). At distant campaign camera depths, that separation can collapse into the same depth-buffer value as the terrain, producing intermittent z-fighting during camera movement such as the pre-nuke sequence.

The projected-decal path already requests D3D8 Z-bias, and the D3D8 reference defines Z-bias specifically for keeping coplanar surfaces visibly separated. The scorch pass did not request it. This change gives only that pass a one-unit bias and preserves surrounding render state.

## User impact

Persistent explosion marks should remain stably above terrain instead of flickering as the camera moves.

## Verification

- `npm run build:port`
- `SKIRMISH_START_SCORCH_PROBE=1 node harness/skirmish_start_smoke.mjs`
  - booted the real engine, navigated the real menus, and entered an active skirmish
  - fired `WeaponFX_BattleshipTargetExplode` through the real FX list beside `Nuke_ChinaVehicleDozer`
  - captured `EXScorch01.tga` at draw sequence 52011 with `zBias: 1`
  - confirmed WebGL polygon offset `{ enabled: true, factor: -1, units: -2 }`
  - saved and visually inspected the intact 1280x720 gameplay screenshot
- RTX 4080 hardware verification on `llmtrain`
  - Chromium reported `ANGLE (NVIDIA, Vulkan 1.4.325 (NVIDIA NVIDIA GeForce RTX 4080 ...), NVIDIA)`
  - the shared GPU was nearly full from an unrelated workload, so Chromium compositing/rasterization was kept on CPU while the WebGL game renderer remained on the RTX 4080
- `node --check WebAssembly/harness/skirmish_start_smoke.mjs`
- `git diff --check`

The exact China campaign pre-nuke sequence was not replayed, but the focused hardware probe exercises the same real terrain-scorch render path with shipped explosion FX and a China faction target.

Agent-Model: OpenAI gpt-5.6-sol