### PR TITLE
Restore audio after tab suspension

### DIFF
--- a/WebAssembly/harness/audio_tab_recovery_smoke.mjs
+++ b/WebAssembly/harness/audio_tab_recovery_smoke.mjs
@@ -1,0 +1,171 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import { chromium } from "playwright";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { startStaticServer } from "./static-server.mjs";
+
+const harnessRoot = dirname(fileURLToPath(import.meta.url));
+const wasmRoot = resolve(harnessRoot, "..");
+const server = await startStaticServer({ root: wasmRoot, port: 0, host: "127.0.0.1" });
+const browser = await chromium.launch({ headless: true });
+
+try {
+  const context = await browser.newContext({ viewport: { width: 1280, height: 800 } });
+  await context.addInitScript(() => {
+    let visibilityState = "visible";
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      get: () => visibilityState,
+    });
+
+    class LifecycleAudioContext extends EventTarget {
+      constructor() {
+        super();
+        this.state = "suspended";
+        this.currentTime = 0;
+        this.baseLatency = 0;
+        this.outputLatency = 0;
+        this.destination = {};
+        this.resumeCalls = 0;
+        this.suspendCalls = 0;
+        globalThis.__lifecycleAudioContext = this;
+      }
+
+      createGain() {
+        return {
+          gain: { value: 1 },
+          connect() {},
+          disconnect() {},
+        };
+      }
+
+      async resume() {
+        this.resumeCalls += 1;
+        this.state = "running";
+        this.currentTime += 0.1;
+        this.dispatchEvent(new Event("statechange"));
+      }
+
+      async suspend() {
+        this.suspendCalls += 1;
+        this.state = "suspended";
+        this.dispatchEvent(new Event("statechange"));
+      }
+
+      async close() {
+        this.state = "closed";
+        this.dispatchEvent(new Event("statechange"));
+      }
+    }
+
+    Object.defineProperty(globalThis, "AudioContext", {
+      configurable: true,
+      value: LifecycleAudioContext,
+    });
+    globalThis.__setLifecycleVisibility = (state) => {
+      visibilityState = state;
+    };
+  });
+
+  const page = await context.newPage();
+  await page.goto(new URL("harness/play.html?diag=lite", server.url).href, {
+    waitUntil: "domcontentloaded",
+  });
+  await page.waitForFunction(() => Boolean(window.CnCPort?.rpc));
+
+  await page.mouse.click(4, 4);
+  await page.waitForFunction(async () => {
+    const result = await window.CnCPort.rpc("browserAudioRuntime");
+    return result.browserAudioRuntime?.contextState === "running";
+  });
+  await page.evaluate(() => window.CnCPort.rpc("setBrowserAudioMixerVolumes", {
+    trigger: "audio-tab-recovery-smoke",
+    scriptVolumes: { music: 0, sound: 0.4, sound3D: 0.5, speech: 0.25 },
+    systemVolumes: { music: 0.9, sound: 0.5, sound3D: 0.2, speech: 0.8 },
+    zoomVolume: 0.5,
+  }));
+
+  async function suspendWhileHidden() {
+    return page.evaluate(async () => {
+      window.__setLifecycleVisibility("hidden");
+      const before = window.__lifecycleAudioContext.resumeCalls;
+      await window.__lifecycleAudioContext.suspend();
+      await new Promise((resolveDelay) => setTimeout(resolveDelay, 0));
+      return {
+        before,
+        after: window.__lifecycleAudioContext.resumeCalls,
+        state: window.__lifecycleAudioContext.state,
+      };
+    });
+  }
+
+  async function assertRecovered(trigger, activate) {
+    const hidden = await suspendWhileHidden();
+    assert.equal(hidden.state, "suspended", "hidden AudioContext did not suspend");
+    assert.equal(hidden.after, hidden.before, "hidden statechange resumed background audio");
+
+    await page.evaluate(activate);
+    await page.waitForFunction((expectedTrigger) => window.CnCPort.rpc("browserAudioRuntime")
+      .then((result) => result.browserAudioRuntime?.contextState === "running"
+        && result.browserAudioRuntime?.lastResumeTrigger === expectedTrigger), trigger);
+  }
+
+  await assertRecovered("document.visibilitychange", () => {
+    window.__setLifecycleVisibility("visible");
+    document.dispatchEvent(new Event("visibilitychange"));
+  });
+  await assertRecovered("window.focus", () => {
+    window.__setLifecycleVisibility("visible");
+    window.dispatchEvent(new Event("focus"));
+  });
+  await assertRecovered("window.pageshow", () => {
+    window.__setLifecycleVisibility("visible");
+    window.dispatchEvent(new Event("pageshow"));
+  });
+
+  await page.evaluate(async () => {
+    window.__setLifecycleVisibility("visible");
+    await window.__lifecycleAudioContext.suspend();
+  });
+  await page.waitForFunction(() => window.CnCPort.rpc("browserAudioRuntime")
+    .then((result) => result.browserAudioRuntime?.contextState === "running"
+      && result.browserAudioRuntime?.lastResumeTrigger === "context.statechange"));
+
+  const result = await page.evaluate(async () => {
+    const [audio, mixer] = await Promise.all([
+      window.CnCPort.rpc("browserAudioRuntime"),
+      window.CnCPort.rpc("browserAudioMixerRuntime"),
+    ]);
+    return {
+      audio: audio.browserAudioRuntime,
+      mixer: mixer.browserAudioMixerRuntime,
+      resumeCalls: window.__lifecycleAudioContext.resumeCalls,
+      suspendCalls: window.__lifecycleAudioContext.suspendCalls,
+    };
+  });
+
+  assert.equal(result.audio.contextCreations, 1, "tab recovery replaced the AudioContext");
+  assert.equal(result.mixer.creations, 1, "tab recovery duplicated the mixer graph");
+  assert.deepEqual(result.mixer.busGains, {
+    music: 0,
+    sound: 0.2,
+    sound3D: 0.05,
+    speech: 0.2,
+  }, "tab recovery reset mute/volume state");
+
+  process.stdout.write(`${JSON.stringify({
+    ok: true,
+    resumeCalls: result.resumeCalls,
+    suspendCalls: result.suspendCalls,
+    contextCreations: result.audio.contextCreations,
+    mixerCreations: result.mixer.creations,
+    busGains: result.mixer.busGains,
+  }, null, 2)}\n`);
+
+  await context.close();
+} finally {
+  await browser.close();
+  await server.close();
+}

--- a/WebAssembly/harness/bridge.js
+++ b/WebAssembly/harness/bridge.js
@@ -2252,6 +2252,8 @@ function ensureBrowserAudioRuntimeContext(trigger) {
       };
       if (state === "running") {
         ensureBrowserAudioMixerRuntime();
+      } else if (state === "suspended") {
+        recoverBrowserAudioRuntime("context.statechange");
       }
     });
     return browserAudioRuntime.context;
@@ -2298,6 +2300,17 @@ async function resumeBrowserAudioRuntime(trigger = "rpc.resumeBrowserAudioRuntim
     browserAudioRuntime.lastResumeError = error?.message ?? String(error);
   }
   return summarizeBrowserAudioRuntime();
+}
+
+function recoverBrowserAudioRuntime(trigger) {
+  const context = browserAudioRuntime.context;
+  if (!context
+      || context.state !== "suspended"
+      || browserAudioRuntime.resumeSuccesses === 0
+      || globalThis.document?.visibilityState === "hidden") {
+    return;
+  }
+  void resumeBrowserAudioRuntime(trigger);
 }
 
 function normalizeBrowserAudioMixerVolumes(defaults, overrides) {
@@ -22884,6 +22897,22 @@ window.addEventListener("pointerdown", () => {
 window.addEventListener("click", () => {
   void resumeBrowserAudioRuntime("window.click");
 }, { capture: true });
+
+// Browsers can release audio hardware while a tab is backgrounded and leave
+// an already-authorized context suspended. Recover that existing context when
+// the page becomes active again; the ordinary input hooks remain the fallback
+// for browsers that require a fresh user activation.
+document.addEventListener("visibilitychange", () => {
+  if (document.visibilityState === "visible") {
+    recoverBrowserAudioRuntime("document.visibilitychange");
+  }
+});
+window.addEventListener("focus", () => {
+  recoverBrowserAudioRuntime("window.focus");
+});
+window.addEventListener("pageshow", () => {
+  recoverBrowserAudioRuntime("window.pageshow");
+});
 
 canvas.addEventListener("pointermove", (event) => {
   const point = canvasInputPointFromEvent(event);

--- a/WebAssembly/package.json
+++ b/WebAssembly/package.json
@@ -101,6 +101,7 @@
     "verify:launcher-polish": "node harness/launcher_polish_smoke.mjs",
     "verify:launcher-polish-browser": "node harness/launcher_polish_browser_smoke.mjs",
     "verify:audio-startup-activation": "node harness/audio_startup_activation_smoke.mjs",
+    "verify:audio-tab-recovery": "node harness/audio_tab_recovery_smoke.mjs",
     "test:real-fx-render": "npm run build:port && node harness/real_fx_render_smoke.mjs",
     "test:real-heat-distortion": "npm run build:port && REAL_FX_EXPECT_HEAT=1 node harness/real_fx_render_smoke.mjs",
     "test:real-laser-draw": "npm run build:port && node harness/real_laser_draw_smoke.mjs",


### PR DESCRIPTION
## What changed

- recover an already-authorized Web Audio context when it becomes suspended while the game page is visible
- retry recovery when the tab becomes visible, regains focus, or returns from the back/forward cache
- keep the initial user-gesture gate intact and reuse the existing AudioContext and mixer graph
- add a focused browser regression covering all recovery triggers and mixer-volume preservation

## Root cause

The browser bridge observed AudioContext state changes but only retried `resume()` on pointer, click, keydown, or initial play start. If the browser suspended a previously running context while the tab was backgrounded, returning to the tab did not trigger recovery. Opening Options and clicking Accept happened to recover audio only because that interaction reached the global input listeners.

## Impact

Audio resumes automatically after returning to the game tab. Recovery does not recreate the AudioContext, duplicate mixer buses, or reset current mute/volume gains.

## Verification

- `npm run verify:audio-tab-recovery`
- `CNC_AUDIO_COLD_LAUNCHES=3 npm run verify:audio-startup-activation`
- `npm run build:port`
- `node --check WebAssembly/harness/bridge.js`
- `node --check WebAssembly/harness/audio_tab_recovery_smoke.mjs`
- `git diff --check`

Fixes #36

Agent-Model: OpenAI GPT-5 Codex