### PR TITLE
Flush threaded renderer batches per frame

### DIFF
--- a/WebAssembly/harness/bridge.js
+++ b/WebAssembly/harness/bridge.js
@@ -897,6 +897,18 @@ function threadedWorkerDiagLevel() {
   }
 }
 
+function threadedWorkerPerfCounters() {
+  try {
+    const value = new URLSearchParams(globalThis.location?.search || "")
+      .get("perfCounters");
+    if (value === "1" || value === "true") return true;
+    if (value === "0" || value === "false") return false;
+  } catch (_error) {
+    // The worker follows its diagnostics level when no override is available.
+  }
+  return null;
+}
+
 function threadedWorkerShaderTier() {
   // The executor samples the shader tier once at device create via
   // d3d8ShaderTierQuery (URL ?shaderTier= param, then localStorage
@@ -1194,6 +1206,7 @@ function createThreadedEngineController() {
         canvas: offscreen,
         options: {
           diagLevel: threadedWorkerDiagLevel(),
+          perfCounters: threadedWorkerPerfCounters(),
           preserveDrawingBuffer: contextPreserveDrawingBuffer,
           shaderTier: threadedWorkerShaderTier(),
           udpBridge: threadedUdpBridge,

--- a/WebAssembly/harness/engine_realm_boot.mjs
+++ b/WebAssembly/harness/engine_realm_boot.mjs
@@ -139,6 +139,9 @@ export default async function setupEngineRealm({ canvas, Module, realm, options 
       && typeof globalThis.__cncSetDiagLevel === "function") {
     globalThis.__cncSetDiagLevel(opts.diagLevel);
   }
+  if (typeof opts.perfCounters === "boolean") {
+    globalThis.__cncSetD3D8PerfCounters?.(opts.perfCounters);
+  }
 
   // ---- GDI text hooks (synchronous returns -> must live in this realm) ------
   const gdiHooks = createGdiHooks();

--- a/WebAssembly/harness/engine_realm_boot.mjs
+++ b/WebAssembly/harness/engine_realm_boot.mjs
@@ -702,6 +702,18 @@ export default async function setupEngineRealm({ canvas, Module, realm, options 
   };
   let framePacedFn = null;
 
+  function runPacedFrame(runLogic) {
+    try {
+      return parseMaybeJson(framePacedFn(runLogic ? 1 : 0));
+    } finally {
+      // Lite rendering may defer the final indexed draw so it can be merged
+      // with an adjacent range.  The main-realm frame RPCs flush that draw
+      // after every engine frame; the autonomous worker loop must preserve
+      // the same frame boundary or the next frame's clear discards it.
+      d3d8Diag.flushD3D8PendingDrawBatch("threadedFramePaced");
+    }
+  }
+
   function startLoop(msg, respond) {
     const clientFps = Math.max(1, Math.min(240, Number(msg.clientFps ?? 60)));
     const logicFps = Math.max(1, Math.min(240, Number(msg.logicFps ?? 30)));
@@ -776,10 +788,10 @@ export default async function setupEngineRealm({ canvas, Module, realm, options 
     let result = null;
     try {
       if (logicToRun === 0) {
-        result = parseMaybeJson(framePacedFn(0));
+        result = runPacedFrame(false);
       } else {
         for (let i = 0; i < logicToRun; i += 1) {
-          result = parseMaybeJson(framePacedFn(1));
+          result = runPacedFrame(true);
           loop.logicFrames += 1;
         }
       }

--- a/WebAssembly/harness/threaded_play_gate.mjs
+++ b/WebAssembly/harness/threaded_play_gate.mjs
@@ -510,10 +510,20 @@ async function main() {
       loopError: loopB?.error ?? null,
       frame: statusB?.status?.frame ?? null,
     };
+    const drawBatchPerf = statusB?.status?.graphics?.d3d8Perf ?? {};
+    summary.pacing.drawBatches = {
+      queued: drawBatchPerf.drawBatchQueued ?? null,
+      flushed: drawBatchPerf.drawBatchFlushes ?? null,
+    };
     log(`paced loop measured over ${seconds.toFixed(1)}s: client ${clientRate.toFixed(1)}/s logic ${logicRate.toFixed(1)}/s`);
     checks.push(["paced loop active on the engine thread", loopB?.active === true]);
     checks.push(["client frames advancing", clientRate > 1]);
     checks.push(["logic frames advancing", logicRate > 0.5]);
+    checks.push([
+      "threaded frame boundaries submit every queued draw batch",
+      Number(drawBatchPerf.drawBatchQueued ?? -1) >= 0
+        && drawBatchPerf.drawBatchQueued === drawBatchPerf.drawBatchFlushes,
+    ]);
     checks.push([
       // Paced-mode invariant: logic never exceeds catchup (2) logic frames
       // per client frame. Under SwiftShader overload the loop legitimately

--- a/WebAssembly/harness/threaded_play_gate.mjs
+++ b/WebAssembly/harness/threaded_play_gate.mjs
@@ -375,7 +375,7 @@ async function main() {
     summary.desktopReference = desktopReferencePath;
 
     // ---------- threaded boot (GATE B) ----------
-    const threadedQuery = "harness/play.html?autostart=1"
+    const threadedQuery = "harness/play.html?autostart=1&perfCounters=1"
       + (BINK_VIDEO_ONLY ? "&shellmap=0" : "")
       + (BINK_VIDEO_ONLY && !BINK_VIDEO_DISABLED ? "&videos=1" : "")
       + (threadedPlayDist ? `&dist=${threadedPlayDist}` : "");
@@ -521,7 +521,8 @@ async function main() {
     checks.push(["logic frames advancing", logicRate > 0.5]);
     checks.push([
       "threaded frame boundaries submit every queued draw batch",
-      Number(drawBatchPerf.drawBatchQueued ?? -1) >= 0
+      drawBatchPerf.countersEnabled === true
+        && Number(drawBatchPerf.drawBatchQueued ?? 0) > 0
         && drawBatchPerf.drawBatchQueued === drawBatchPerf.drawBatchFlushes,
     ]);
     checks.push([


### PR DESCRIPTION
## Summary

- flush the D3D8 executor's deferred adjacent draw batch after every autonomous worker-realm paced frame, including catch-up frames and exception paths
- pass an opt-in performance-counter override into the engine worker without changing normal play diagnostics
- make the production-threaded gate require active, nonzero, exactly balanced queued/flushed draw batches

## Root cause and impact

The main-realm frame RPCs already established a frame boundary by flushing the executor after each engine frame, but the shipping autonomous worker loop did not. In lite rendering mode the final indexed draw could remain deferred until the next frame clear, where it was discarded. Stable terrain draw order made the missing 32x32 shroud/terrain block persist for an entire match.

The worker loop now preserves the same submit boundary as the main-realm path. Product play keeps its existing lite diagnostics behavior; counters are explicitly enabled only by the regression gate.

Closes #25

## Verification

- `node --check` on `bridge.js`, `engine_realm_boot.mjs`, and `threaded_play_gate.mjs`
- `npm run verify:save-persistence-order`
- `npm run verify:runtime-shutdown-order`
- fresh `npm run build:port`
- `npm run test:d3d8-offscreen-viewport-browser`
- fresh `build:port:threaded:release` at `081f7c2f` on an RTX 4080 using ANGLE/Vulkan with software rasterization disabled
- two current-commit GPU gate measurements balanced all deferred batches (`56,944/56,944` and `56,389/56,389`) while sustaining approximately 60 client / 30 logic FPS
- current threaded shell-map capture visually inspected without a bright/clear terrain block; earlier issue evidence covers three skirmish runs and a 25-position Alpine Assault camera sweep

The full aggregate threaded gate remains nonzero on unrelated pointer/cursor checks and the Bink group (Bink was explicitly disabled for this run). The issue-specific batch assertion and the mount, init, rendering, pacing, RPC, audio, resolution, persistence, and shutdown paths passed.

Agent-Model: OpenAI gpt-5.6-sol
