### PR TITLE
Fix Tech Reinforcement Pad rendering

### DIFF
--- a/WebAssembly/harness/d3d8_alpha_cutout_unit.mjs
+++ b/WebAssembly/harness/d3d8_alpha_cutout_unit.mjs
@@ -1,0 +1,169 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import { createD3D8Executor } from "./d3d8_executor.mjs";
+
+const D3DFMT_A8R8G8B8 = 21;
+const D3DFMT_DXT1 = 0x31545844;
+const D3DFMT_DXT5 = 0x35545844;
+
+function makeDxt5Block(alphaSelectors) {
+  assert.equal(alphaSelectors.length, 16);
+  const block = new Uint8Array(16);
+  block[0] = 255;
+  block[1] = 0;
+  let packed = 0;
+  for (let texel = 0; texel < alphaSelectors.length; ++texel) {
+    packed += alphaSelectors[texel] * (2 ** (texel * 3));
+  }
+  for (let byte = 0; byte < 6; ++byte) {
+    block[2 + byte] = Math.floor(packed / (2 ** (byte * 8))) & 0xff;
+  }
+  return block;
+}
+
+function makeDxt1Block(colorSelectors) {
+  assert.equal(colorSelectors.length, 16);
+  const block = new Uint8Array(8);
+  block[0] = 0;
+  block[1] = 0;
+  block[2] = 0xff;
+  block[3] = 0xff;
+  let packed = 0;
+  for (let texel = 0; texel < colorSelectors.length; ++texel) {
+    packed += colorSelectors[texel] * (2 ** (texel * 2));
+  }
+  for (let byte = 0; byte < 4; ++byte) {
+    block[4 + byte] = Math.floor(packed / (2 ** (byte * 8))) & 0xff;
+  }
+  return block;
+}
+
+const { diag } = createD3D8Executor({
+  canvas: {
+    width: 1,
+    height: 1,
+    addEventListener() {},
+    getContext() { return null; },
+  },
+  gl: null,
+  fallbackContext: null,
+  log() {},
+  state: { canvas: {}, graphics: {} },
+});
+
+const mostlyOpaqueDxt5 = makeDxt5Block([
+  1, 0, 0, 0,
+  0, 0, 0, 0,
+  0, 0, 0, 0,
+  0, 0, 0, 0,
+]);
+const mostlyTransparentDxt5 = makeDxt5Block([
+  0, 1, 1, 1,
+  1, 1, 1, 1,
+  1, 1, 1, 1,
+  1, 1, 1, 1,
+]);
+const dxt1Cutout = makeDxt1Block([
+  3, 0, 0, 0,
+  0, 0, 0, 0,
+  0, 0, 0, 0,
+  0, 0, 0, 0,
+]);
+
+const mostlyOpaqueCoverage = diag.d3d8TextureAlphaCoverage(
+  D3DFMT_DXT5, mostlyOpaqueDxt5, 4, 4);
+const mostlyTransparentCoverage = diag.d3d8TextureAlphaCoverage(
+  D3DFMT_DXT5, mostlyTransparentDxt5, 4, 4);
+assert.deepEqual(mostlyOpaqueCoverage, {
+  nonzeroTexels: 15,
+  totalTexels: 16,
+  nonzeroCoverage: 15 / 16,
+});
+assert.deepEqual(mostlyTransparentCoverage, {
+  nonzeroTexels: 1,
+  totalTexels: 16,
+  nonzeroCoverage: 1 / 16,
+});
+assert.equal(
+  diag.d3d8TextureAlphaCoverage(D3DFMT_DXT1, dxt1Cutout, 4, 4).nonzeroTexels,
+  15,
+);
+assert.deepEqual(
+  diag.d3d8TextureAlphaCoverage(
+    D3DFMT_A8R8G8B8,
+    new Uint8Array([
+      1, 2, 3, 255,
+      4, 5, 6, 0,
+    ]),
+    2,
+    1,
+  ),
+  { nonzeroTexels: 1, totalTexels: 2, nonzeroCoverage: 0.5 },
+);
+
+const textureStage0 = {
+  alphaOp: 4,
+  alphaArg0: 1,
+  alphaArg1: 2,
+  alphaArg2: 0,
+  resultArg: 1,
+};
+const renderState = {
+  alphaTestEnable: 0,
+  alphaBlendEnable: 0,
+  zEnable: 1,
+  zWriteEnable: 1,
+  textureStages: [textureStage0, { alphaOp: 1 }],
+};
+const eligibleTexture = {
+  format: D3DFMT_DXT5,
+  alphaCoverage: mostlyOpaqueCoverage,
+};
+const ineligibleTexture = {
+  format: D3DFMT_DXT5,
+  alphaCoverage: mostlyTransparentCoverage,
+};
+
+assert.equal(diag.d3d8TextureSupportsImplicitAlphaCutout(eligibleTexture), true);
+assert.equal(diag.d3d8TextureSupportsImplicitAlphaCutout(ineligibleTexture), false);
+assert.equal(
+  diag.d3d8ImplicitAlphaCutoutThreshold(
+    renderState, true, eligibleTexture, false, null),
+  1 / 255,
+);
+assert.equal(
+  diag.d3d8ImplicitAlphaCutoutThreshold(
+    renderState, true, ineligibleTexture, false, null),
+  -1,
+);
+assert.equal(
+  diag.d3d8ImplicitAlphaCutoutThreshold({
+    ...renderState,
+    textureStages: [textureStage0, {
+      alphaOp: 4,
+      alphaArg0: 0,
+      alphaArg1: 1,
+      alphaArg2: 2,
+      resultArg: 1,
+    }],
+  }, true, eligibleTexture, true, ineligibleTexture),
+  -1,
+);
+assert.equal(
+  diag.d3d8ImplicitAlphaCutoutThreshold(
+    { ...renderState, alphaTestEnable: 1 }, true, eligibleTexture, false, null),
+  -1,
+);
+assert.equal(
+  diag.d3d8ImplicitAlphaCutoutThreshold(
+    { ...renderState, alphaBlendEnable: 1 }, true, eligibleTexture, false, null),
+  -1,
+);
+
+console.log(JSON.stringify({
+  ok: true,
+  source: "d3d8-alpha-cutout-unit",
+  mostlyOpaqueCoverage,
+  mostlyTransparentCoverage,
+}));

--- a/WebAssembly/harness/d3d8_executor.mjs
+++ b/WebAssembly/harness/d3d8_executor.mjs
@@ -4908,6 +4908,135 @@ function d3d8TextureFormatHasAlpha(format) {
   }
 }
 
+const D3D8_IMPLICIT_ALPHA_CUTOUT_MIN_NONZERO_COVERAGE = 0.5;
+
+function d3d8TextureAlphaCoverage(format, bytes, width, height) {
+  const d3dFormat = Number(format) >>> 0;
+  const textureWidth = Number(width) >>> 0;
+  const textureHeight = Number(height) >>> 0;
+  const totalTexels = textureWidth * textureHeight;
+  if (!(bytes instanceof Uint8Array) || totalTexels === 0) {
+    return null;
+  }
+
+  const finish = (nonzeroTexels) => ({
+    nonzeroTexels,
+    totalTexels,
+    nonzeroCoverage: nonzeroTexels / totalTexels,
+  });
+  let nonzeroTexels = 0;
+
+  if (d3dFormat === D3DFMT_A8R8G8B8) {
+    if (bytes.length < totalTexels * 4) return null;
+    for (let texel = 0; texel < totalTexels; ++texel) {
+      if (bytes[texel * 4 + 3] !== 0) ++nonzeroTexels;
+    }
+    return finish(nonzeroTexels);
+  }
+  if (d3dFormat === D3DFMT_A1R5G5B5 || d3dFormat === D3DFMT_A4R4G4B4) {
+    if (bytes.length < totalTexels * 2) return null;
+    const alphaMask = d3dFormat === D3DFMT_A1R5G5B5 ? 0x8000 : 0xf000;
+    for (let texel = 0; texel < totalTexels; ++texel) {
+      const offset = texel * 2;
+      const value = bytes[offset] | (bytes[offset + 1] << 8);
+      if ((value & alphaMask) !== 0) ++nonzeroTexels;
+    }
+    return finish(nonzeroTexels);
+  }
+  if (d3dFormat === D3DFMT_A8 || d3dFormat === D3DFMT_A8L8) {
+    const texelBytes = d3dFormat === D3DFMT_A8 ? 1 : 2;
+    const alphaOffset = texelBytes - 1;
+    if (bytes.length < totalTexels * texelBytes) return null;
+    for (let texel = 0; texel < totalTexels; ++texel) {
+      if (bytes[texel * texelBytes + alphaOffset] !== 0) ++nonzeroTexels;
+    }
+    return finish(nonzeroTexels);
+  }
+
+  const dxt1 = d3dFormat === D3DFMT_DXT1;
+  const dxt3 = d3dFormat === D3DFMT_DXT2 || d3dFormat === D3DFMT_DXT3;
+  const dxt5 = d3dFormat === D3DFMT_DXT4 || d3dFormat === D3DFMT_DXT5;
+  if (!dxt1 && !dxt3 && !dxt5) {
+    return null;
+  }
+
+  const blockWidth = Math.ceil(textureWidth / 4);
+  const blockHeight = Math.ceil(textureHeight / 4);
+  const bytesPerBlock = dxt1 ? 8 : 16;
+  if (bytes.length < blockWidth * blockHeight * bytesPerBlock) {
+    return null;
+  }
+
+  for (let blockY = 0; blockY < blockHeight; ++blockY) {
+    for (let blockX = 0; blockX < blockWidth; ++blockX) {
+      const blockOffset = (blockY * blockWidth + blockX) * bytesPerBlock;
+      let alphaIndices = 0;
+      let nonzeroAlphaMask = 0xff;
+      let dxt1HasTransparentIndex = false;
+
+      if (dxt1) {
+        const color0 = bytes[blockOffset] | (bytes[blockOffset + 1] << 8);
+        const color1 = bytes[blockOffset + 2] | (bytes[blockOffset + 3] << 8);
+        dxt1HasTransparentIndex = color0 <= color1;
+        alphaIndices = bytes[blockOffset + 4]
+          + bytes[blockOffset + 5] * 0x100
+          + bytes[blockOffset + 6] * 0x10000
+          + bytes[blockOffset + 7] * 0x1000000;
+      } else if (dxt5) {
+        const alpha0 = bytes[blockOffset];
+        const alpha1 = bytes[blockOffset + 1];
+        nonzeroAlphaMask = (alpha0 !== 0 ? 0x01 : 0) | (alpha1 !== 0 ? 0x02 : 0);
+        if (alpha0 > alpha1) {
+          if (Math.round((6 * alpha0 + alpha1) / 7) !== 0) nonzeroAlphaMask |= 0x04;
+          if (Math.round((5 * alpha0 + 2 * alpha1) / 7) !== 0) nonzeroAlphaMask |= 0x08;
+          if (Math.round((4 * alpha0 + 3 * alpha1) / 7) !== 0) nonzeroAlphaMask |= 0x10;
+          if (Math.round((3 * alpha0 + 4 * alpha1) / 7) !== 0) nonzeroAlphaMask |= 0x20;
+          if (Math.round((2 * alpha0 + 5 * alpha1) / 7) !== 0) nonzeroAlphaMask |= 0x40;
+          if (Math.round((alpha0 + 6 * alpha1) / 7) !== 0) nonzeroAlphaMask |= 0x80;
+        } else {
+          if (Math.round((4 * alpha0 + alpha1) / 5) !== 0) nonzeroAlphaMask |= 0x04;
+          if (Math.round((3 * alpha0 + 2 * alpha1) / 5) !== 0) nonzeroAlphaMask |= 0x08;
+          if (Math.round((2 * alpha0 + 3 * alpha1) / 5) !== 0) nonzeroAlphaMask |= 0x10;
+          if (Math.round((alpha0 + 4 * alpha1) / 5) !== 0) nonzeroAlphaMask |= 0x20;
+          // In six-value mode selector 6 is zero and selector 7 is 255.
+          nonzeroAlphaMask |= 0x80;
+        }
+        for (let byte = 0; byte < 6; ++byte) {
+          alphaIndices += bytes[blockOffset + 2 + byte] * (2 ** (byte * 8));
+        }
+      }
+
+      const validWidth = Math.min(4, textureWidth - blockX * 4);
+      const validHeight = Math.min(4, textureHeight - blockY * 4);
+      for (let y = 0; y < validHeight; ++y) {
+        for (let x = 0; x < validWidth; ++x) {
+          const texel = y * 4 + x;
+          let alpha = 255;
+          if (dxt1) {
+            const index = Math.floor(alphaIndices / (2 ** (texel * 2))) % 4;
+            alpha = dxt1HasTransparentIndex && index === 3 ? 0 : 255;
+          } else if (dxt3) {
+            const packed = bytes[blockOffset + Math.floor(texel / 2)];
+            alpha = (texel & 1) === 0 ? (packed & 0x0f) : (packed >> 4);
+          } else {
+            const index = Math.floor(alphaIndices / (2 ** (texel * 3))) % 8;
+            alpha = nonzeroAlphaMask & (1 << index);
+          }
+          if (alpha !== 0) ++nonzeroTexels;
+        }
+      }
+    }
+  }
+  return finish(nonzeroTexels);
+}
+
+function d3d8TextureSupportsImplicitAlphaCutout(resource) {
+  const coverage = Number(resource?.alphaCoverage?.nonzeroCoverage);
+  return d3d8TextureFormatHasAlpha(resource?.format) &&
+    Number.isFinite(coverage) &&
+    coverage >= D3D8_IMPLICIT_ALPHA_CUTOUT_MIN_NONZERO_COVERAGE;
+}
+
 function d3d8TextureStageAlphaUsesBase(textureStage, base) {
   if (!textureStage || Number(textureStage.alphaOp) >>> 0 === D3DTOP_DISABLE) {
     return false;
@@ -4921,33 +5050,42 @@ function d3d8TextureStageAlphaUsesBase(textureStage, base) {
     || (d3dTextureCombinerOpUsesArg2(alphaOp) && (alphaArg2 & D3DTA_SELECTMASK) === base);
 }
 
-function d3d8FinalAlphaMayUseTexture(renderState, canSampleTexture0, texture0Resource,
+const D3D8_ALPHA_TEXTURE_CUTOUT_ELIGIBLE = 1;
+const D3D8_ALPHA_TEXTURE_CUTOUT_INELIGIBLE = 2;
+
+function d3d8TextureAlphaCutoutState(resource) {
+  if (!d3d8TextureFormatHasAlpha(resource?.format)) {
+    return 0;
+  }
+  return d3d8TextureSupportsImplicitAlphaCutout(resource)
+    ? D3D8_ALPHA_TEXTURE_CUTOUT_ELIGIBLE
+    : D3D8_ALPHA_TEXTURE_CUTOUT_INELIGIBLE;
+}
+
+function d3d8FinalAlphaTextureCutoutState(renderState, canSampleTexture0, texture0Resource,
     canSampleTexture1, texture1Resource) {
   const stage0 = renderState?.textureStages?.[0] ?? null;
   const stage1 = renderState?.textureStages?.[1] ?? null;
-  const stage0TextureAlpha = Boolean(
-    canSampleTexture0 &&
-    d3d8TextureFormatHasAlpha(texture0Resource?.format) &&
-    d3d8TextureStageAlphaUsesBase(stage0, D3DTA_TEXTURE),
-  );
-  const stage0CurrentAlpha = stage0TextureAlpha &&
-    ((Number(stage0?.resultArg ?? D3DTA_CURRENT) >>> 0) !== D3DTA_TEMP);
-  const stage0TempAlpha = stage0TextureAlpha &&
-    ((Number(stage0?.resultArg ?? D3DTA_CURRENT) >>> 0) === D3DTA_TEMP);
+  const stage0TextureAlpha = canSampleTexture0 &&
+    d3d8TextureStageAlphaUsesBase(stage0, D3DTA_TEXTURE)
+    ? d3d8TextureAlphaCutoutState(texture0Resource)
+    : 0;
+  const stage0WritesTemp = (Number(stage0?.resultArg ?? D3DTA_CURRENT) >>> 0) === D3DTA_TEMP;
+  const stage0CurrentAlpha = stage0WritesTemp ? 0 : stage0TextureAlpha;
+  const stage0TempAlpha = stage0WritesTemp ? stage0TextureAlpha : 0;
 
   const stage1AlphaOp = Number(stage1?.alphaOp ?? D3DTOP_DISABLE) >>> 0;
   if (stage1AlphaOp === D3DTOP_DISABLE) {
     return stage0CurrentAlpha;
   }
 
-  const stage1TextureAlpha = Boolean(
-    canSampleTexture1 &&
-    d3d8TextureFormatHasAlpha(texture1Resource?.format) &&
-    d3d8TextureStageAlphaUsesBase(stage1, D3DTA_TEXTURE),
-  );
-  return stage1TextureAlpha ||
-    (stage0CurrentAlpha && d3d8TextureStageAlphaUsesBase(stage1, D3DTA_CURRENT)) ||
-    (stage0TempAlpha && d3d8TextureStageAlphaUsesBase(stage1, D3DTA_TEMP));
+  const stage1TextureAlpha = canSampleTexture1 &&
+    d3d8TextureStageAlphaUsesBase(stage1, D3DTA_TEXTURE)
+    ? d3d8TextureAlphaCutoutState(texture1Resource)
+    : 0;
+  return stage1TextureAlpha |
+    (d3d8TextureStageAlphaUsesBase(stage1, D3DTA_CURRENT) ? stage0CurrentAlpha : 0) |
+    (d3d8TextureStageAlphaUsesBase(stage1, D3DTA_TEMP) ? stage0TempAlpha : 0);
 }
 
 function d3d8ImplicitAlphaCutoutThreshold(renderState, canSampleTexture0, texture0Resource,
@@ -4959,13 +5097,21 @@ function d3d8ImplicitAlphaCutoutThreshold(renderState, canSampleTexture0, textur
       renderState.zWriteEnable === 0) {
     return -1;
   }
-  return d3d8FinalAlphaMayUseTexture(
+  const textureAlphaState = d3d8FinalAlphaTextureCutoutState(
     renderState,
     canSampleTexture0,
     texture0Resource,
     canSampleTexture1,
     texture1Resource,
-  ) ? (1 / 255) : -1;
+  );
+
+  // D3D8 does not discard texels while alpha testing is disabled. This
+  // compatibility path exists only for shipped opaque passes whose mostly
+  // opaque alpha masks contain isolated holes (the shell-map battleship). Do
+  // not infer a cutout when zero alpha is the majority: some opaque materials,
+  // including the Tech Reinforcement Pad tower, carry an auxiliary/unused
+  // alpha channel that would otherwise erase most of the model.
+  return textureAlphaState === D3D8_ALPHA_TEXTURE_CUTOUT_ELIGIBLE ? (1 / 255) : -1;
 }
 
 function d3d8TextureSemanticMode(resource) {
@@ -5308,6 +5454,7 @@ function createD3D8Texture(payload = {}) {
     levelFormats: new Map(),
     completeMipChain: false,
     uploads: 0,
+    alphaCoverage: null,
     samplerState: null,
     samplerStateKey: null,
     samplerD3DStateKey: null,
@@ -5797,6 +5944,11 @@ function updateD3D8Texture(payload = {}) {
   if (x + width > levelSize.width || y + height > levelSize.height) {
     return 0;
   }
+  const level0AlphaCoverage = level !== 0
+    ? undefined
+    : (x === 0 && y === 0 && width === levelSize.width && height === levelSize.height
+      ? d3d8TextureAlphaCoverage(format, payload.bytes, width, height)
+      : null);
 
   const convertStartedAt = perfNow();
   // Handle DXT CPU decoding fallback
@@ -5915,6 +6067,9 @@ function updateD3D8Texture(payload = {}) {
   if (d3d8PerfCountersEnabled) d3d8PerfStats.textureUploadBytes += Number(uploadBytes.byteLength ?? 0) >>> 0;
   if (d3d8PerfCountersEnabled) d3d8PerfStats.textureUploadPixels += Math.max(0, width * height);
   if (d3d8PerfCountersEnabled) d3d8PerfStats.textureUploadMs += perfNow() - uploadStartedAt;
+  if (level0AlphaCoverage !== undefined) {
+    resource.alphaCoverage = level0AlphaCoverage;
+  }
   invalidateD3D8DrawStateCache();
 
   resource.uploads += 1;
@@ -5941,6 +6096,7 @@ function updateD3D8Texture(payload = {}) {
     compressed: Boolean(info.compressed),
     blockBytes: Number(info.blockBytes ?? 0) >>> 0,
     semantic: info.semantic || null,
+    alphaCoverage: resource.alphaCoverage,
     swizzle: swizzleApplied,
     pitch: Number(payload.pitch ?? 0) >>> 0,
     rowBytes: Number(payload.rowBytes ?? 0) >>> 0,
@@ -13786,6 +13942,8 @@ function paintD3D8DrawIndexed(payload = {}) {
       format: texture0Resource?.format ?? 0,
       storage: texture0Resource?.storage ?? null,
       semantic: texture0Resource?.semantic ?? null,
+      alphaCoverage: texture0Resource?.alphaCoverage ?? null,
+      implicitAlphaCutoutEligible: d3d8TextureSupportsImplicitAlphaCutout(texture0Resource),
       semanticMode: texture0SemanticMode,
       uploads: texture0Resource?.uploads ?? 0,
       samplePixels: sampleD3D8TextureProbe(texture0Resource),
@@ -13827,6 +13985,8 @@ function paintD3D8DrawIndexed(payload = {}) {
       format: texture1Resource?.format ?? 0,
       storage: texture1Resource?.storage ?? null,
       semantic: texture1Resource?.semantic ?? null,
+      alphaCoverage: texture1Resource?.alphaCoverage ?? null,
+      implicitAlphaCutoutEligible: d3d8TextureSupportsImplicitAlphaCutout(texture1Resource),
       semanticMode: texture1SemanticMode,
       uploads: texture1Resource?.uploads ?? 0,
       samplePixels: sampleD3D8TextureProbe(texture1Resource),
@@ -13921,6 +14081,8 @@ function paintD3D8DrawIndexed(payload = {}) {
         format: probe.texture0.format,
         storage: probe.texture0.storage,
         semantic: probe.texture0.semantic,
+        alphaCoverage: probe.texture0.alphaCoverage,
+        implicitAlphaCutoutEligible: probe.texture0.implicitAlphaCutoutEligible,
         semanticMode: probe.texture0.semanticMode,
         uploads: probe.texture0.uploads,
         completeMipChain: probe.texture0.completeMipChain,
@@ -13940,6 +14102,8 @@ function paintD3D8DrawIndexed(payload = {}) {
         format: probe.texture1.format,
         storage: probe.texture1.storage,
         semantic: probe.texture1.semantic,
+        alphaCoverage: probe.texture1.alphaCoverage,
+        implicitAlphaCutoutEligible: probe.texture1.implicitAlphaCutoutEligible,
         semanticMode: probe.texture1.semanticMode,
         uploads: probe.texture1.uploads,
         completeMipChain: probe.texture1.completeMipChain,
@@ -14029,6 +14193,9 @@ function paintD3D8DrawIndexed(payload = {}) {
     sampleCanvasPixel,
     sampleCanvasRegion,
     sampleD3D8TexturePixel,
+    d3d8TextureAlphaCoverage,
+    d3d8TextureSupportsImplicitAlphaCutout,
+    d3d8ImplicitAlphaCutoutThreshold,
     sampleVirtualCanvasPixel,
     syncCanvasSize,
     updateD3D8BufferSummary,

--- a/WebAssembly/harness/skirmish_structure_texture_capture.mjs
+++ b/WebAssembly/harness/skirmish_structure_texture_capture.mjs
@@ -28,6 +28,9 @@ const postActiveFrameChunk = parsePositiveInt(
   frameChunk);
 const drawHistoryLimit = parsePositiveInt("SKIRMISH_STRUCTURE_DRAW_HISTORY_LIMIT", 8192);
 const requestedSkirmishMap = String(process.env.SKIRMISH_STRUCTURE_MAP ?? "").trim();
+const requestedTargetName = String(process.env.SKIRMISH_STRUCTURE_TARGET ?? "").trim();
+const expectedNoImplicitCutoutTexture = String(
+  process.env.SKIRMISH_STRUCTURE_EXPECT_NO_IMPLICIT_CUTOUT ?? "").trim().toLowerCase();
 const revealLocalMap = process.env.SKIRMISH_STRUCTURE_REVEAL_MAP !== "0";
 const distDir = parseDistDir();
 let cleanupTimedOut = false;
@@ -344,10 +347,12 @@ async function runPostActiveFrames(page, totalFrames, chunkSize) {
   return { result: last, framesAdvanced, samples };
 }
 
-function chooseEnemyStructure(query) {
+function chooseTargetStructure(query) {
   const all = query?.result?.allDrawables ?? [];
+  const requestedTarget = requestedTargetName.toLowerCase();
   const candidates = all.filter((drawable) =>
-    drawable?.hostileToLocal === true &&
+    (!requestedTarget || String(drawable?.name ?? "").toLowerCase().includes(requestedTarget)) &&
+    (requestedTarget || drawable?.hostileToLocal === true) &&
     drawable?.structure === true &&
     drawable?.worldPos != null &&
     drawable?.effectivelyDead !== true &&
@@ -364,12 +369,13 @@ function chooseEnemyStructure(query) {
     .sort((left, right) => left.score - right.score || left.order - right.order);
 }
 
-async function frameEnemyStructure(page) {
+async function frameTargetStructure(page) {
   const initial = await rpc(page, "queryDrawables");
   expect(initial?.ok === true && initial?.result?.ready === true,
-    "queryDrawables failed before enemy-structure framing", initial);
-  const candidates = chooseEnemyStructure(initial);
-  expect(candidates.length > 0, "no hostile structures were available to frame", {
+    "queryDrawables failed before structure framing", initial);
+  const candidates = chooseTargetStructure(initial);
+  expect(candidates.length > 0, "no matching structures were available to frame", {
+    requestedTargetName: requestedTargetName || null,
     stats: initial.result?.stats ?? null,
     hostile: (initial.result?.allDrawables ?? [])
       .filter((drawable) => drawable?.hostileToLocal === true)
@@ -379,23 +385,23 @@ async function frameEnemyStructure(page) {
   const attempts = [];
   for (const { drawable } of candidates.slice(0, 12)) {
     const lookAt = await rpc(page, "tacticalViewLookAt", { worldPos: drawable.worldPos });
-    expect(lookAt?.ok === true, "tacticalViewLookAt failed for enemy structure", {
+    expect(lookAt?.ok === true, "tacticalViewLookAt failed for structure", {
       target: compactDrawable(drawable),
       lookAt,
     });
-    await runSummary(page, 12, "enemy structure camera settle");
+    await runSummary(page, 12, "structure camera settle");
     const framed = await rpc(page, "queryDrawables");
     expect(framed?.ok === true && framed?.result?.ready === true,
-      "queryDrawables failed after enemy-structure framing", framed);
-    const visible = (framed.result?.enemyDrawables ?? [])
+      "queryDrawables failed after structure framing", framed);
+    const visible = (framed.result?.allDrawables ?? [])
       .filter((candidate) =>
         candidate?.structure === true &&
-        candidate?.hostileToLocal === true &&
+        (requestedTargetName || candidate?.hostileToLocal === true) &&
         candidate?.onScreen === true &&
         candidate?.hidden !== true &&
         (!revealLocalMap || Number(candidate?.shroudStatus ?? 99) < 3));
     const matchingVisible = visible.find((candidate) => candidate.id === drawable.id) ?? null;
-    const selected = matchingVisible ?? visible[0] ?? null;
+    const selected = matchingVisible ?? (requestedTargetName ? null : visible[0] ?? null);
     attempts.push({
       requested: compactDrawable(drawable),
       lookAt: lookAt.result ?? null,
@@ -408,7 +414,8 @@ async function frameEnemyStructure(page) {
     }
   }
 
-  expect(false, "no hostile structure became visible after camera framing", {
+  expect(false, "no matching structure became visible after camera framing", {
+    requestedTargetName: requestedTargetName || null,
     attempts,
     initialStats: initial.result?.stats ?? null,
   });
@@ -600,6 +607,48 @@ function analyzeGeneratedHouseColorTextures(history) {
       whiteOnly: whiteOnly.length,
     },
     textures: Array.from(unique.values()).sort((left, right) => left.name.localeCompare(right.name)),
+  };
+}
+
+function analyzeExpectedNoImplicitCutout(history) {
+  if (!expectedNoImplicitCutoutTexture) {
+    return null;
+  }
+  const draws = history.filter((draw) =>
+    textureLabelName(draw.texture0).includes(expectedNoImplicitCutoutTexture) ||
+    textureLabelName(draw.texture1).includes(expectedNoImplicitCutoutTexture));
+  const opaqueDraws = draws.filter((draw) => {
+    const state = draw.renderState ?? {};
+    return Number(state.alphaTestEnable ?? 0) === 0 &&
+      Number(state.alphaBlendEnable ?? 0) === 0 &&
+      Number(state.zEnable ?? 0) !== 0 &&
+      Number(state.zWriteEnable ?? 0) !== 0;
+  });
+  const unexpectedCutouts = opaqueDraws.filter((draw) =>
+    draw.appliedRenderState?.implicitAlphaCutout?.enabled === true);
+  const errors = [];
+  if (draws.length === 0) {
+    errors.push(`expected texture ${expectedNoImplicitCutoutTexture} was not drawn`);
+  }
+  if (opaqueDraws.length === 0) {
+    errors.push(`expected an opaque depth-writing ${expectedNoImplicitCutoutTexture} draw`);
+  }
+  if (unexpectedCutouts.length > 0) {
+    errors.push(`opaque ${expectedNoImplicitCutoutTexture} draws used implicit cutout at seq ${unexpectedCutouts.map((draw) => draw.seq).join(",")}`);
+  }
+  return {
+    ok: errors.length === 0,
+    texture: expectedNoImplicitCutoutTexture,
+    errors,
+    counts: {
+      draws: draws.length,
+      opaqueDraws: opaqueDraws.length,
+      unexpectedCutouts: unexpectedCutouts.length,
+    },
+    alphaCoverage: Array.from(new Set(draws.flatMap((draw) =>
+      [draw.texture0, draw.texture1]
+        .filter((texture) => textureLabelName(texture).includes(expectedNoImplicitCutoutTexture))
+        .map((texture) => texture.alphaCoverage?.nonzeroCoverage ?? null)))),
   };
 }
 
@@ -843,7 +892,7 @@ async function main() {
     const renderer = await queryRenderer(page);
 
     const skirmishSetup = await enterSkirmish(page, server.url);
-    const framing = await frameEnemyStructure(page);
+    const framing = await frameTargetStructure(page);
 
     await page.evaluate((limit) =>
       window.__cncSetD3D8SceneDrawHistoryLimit?.(limit), drawHistoryLimit);
@@ -858,8 +907,9 @@ async function main() {
     const history = (full.state?.graphics?.d3d8SceneDrawHistory ?? [])
       .map((draw) => compactDraw(draw, labelById));
     const generatedHouseColor = analyzeGeneratedHouseColorTextures(history);
+    const noImplicitCutout = analyzeExpectedNoImplicitCutout(history);
     const targetPatch = analyzeTargetPatch(patch);
-    const ok = targetPatch.ok && generatedHouseColor.ok;
+    const ok = targetPatch.ok && generatedHouseColor.ok && (noImplicitCutout?.ok ?? true);
     const summary = {
       ok,
       source: "skirmish-structure-texture-capture",
@@ -869,6 +919,7 @@ async function main() {
       distDir,
       archiveCount: skirmishSetup.mount.archiveSet.archiveCount,
       requestedMap: requestedSkirmishMap || null,
+      requestedTarget: requestedTargetName || null,
       revealLocalMap: skirmishSetup.reveal?.result ?? null,
       skirmishMapSet: skirmishSetup.skirmishMapSet?.result ?? null,
       framesAdvancedAfterStart: skirmishSetup.active.framesAdvanced,
@@ -893,6 +944,7 @@ async function main() {
       assertions: {
         targetPatch,
         generatedHouseColor,
+        noImplicitCutout,
       },
       captures: {
         history,
@@ -915,6 +967,7 @@ async function main() {
       const errors = [
         ...targetPatch.errors,
         ...generatedHouseColor.errors,
+        ...(noImplicitCutout?.errors ?? []),
       ];
       throw new Error(`skirmish structure texture assertion failed: ${errors.join("; ")}`);
     }

--- a/WebAssembly/package.json
+++ b/WebAssembly/package.json
@@ -158,6 +158,7 @@
     "test:w3d-device-utility": "npm run build:wasm && node dist/w3d-device-utility-smoke.cjs",
     "test:ww3d2-light-render": "npm run build:wasm && node dist/ww3d2-light-render-smoke.cjs",
     "test:d3d8-shim": "npm run build:wasm && node dist/d3d8-shim-smoke.cjs",
+    "test:d3d8-alpha-cutout": "node harness/d3d8_alpha_cutout_unit.mjs",
     "test:d3d8-offscreen-viewport-browser": "node harness/d3d8_offscreen_viewport_smoke.mjs",
     "test:d3d8-render-state-mapping": "npm run build:wasm && node dist/d3d8-render-state-mapping-smoke.cjs",
     "test:d3d8-texture-upload-readiness": "npm run build:wasm && node dist/d3d8-texture-upload-readiness-smoke.cjs",


### PR DESCRIPTION
Fixes #40.

The browser D3D8 bridge treated any unblended, depth-writing texture-alpha draw as an implicit cutout even when alpha testing was disabled. `zblandibay` has only 2.008% non-zero alpha on the opaque tower meshes, so the heuristic discarded almost all of the building.

This measures level-0 alpha coverage during texture upload and keeps the compatibility cutout only for mostly opaque masks with isolated holes. It also adds a focused unit test and extends the structure capture so neutral structures can be targeted and checked for unwanted implicit cutout.

Tested with:

- `npm run test:d3d8-alpha-cutout`
- `npm run build:port`
- Shell-map cutout gate at frames 240 and 360: 25 battleship cutouts, 5 Chinook cutouts, 13 blended Comanche draws, and 115 blended shockwave draws
- Tournament Island on the threaded release with an RTX 4080 Vulkan renderer: `TechReinforcementPad#57` on-screen, 12/12 visible target samples, four `zblandibay` draws, three opaque tower draws, and zero unexpected implicit cutouts

Agent-Model: OpenAI gpt-5.6-sol