### PR TITLE
Deploy dev through trusted Cloudflare handoff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: Pull request CI
 
 on:
+  push:
+    branches: [dev]
   pull_request:
   workflow_dispatch:
 
@@ -71,7 +73,9 @@ jobs:
         run: npm run test:cloudflare-deployment
 
       - name: Upload trusted preview handoff
-        if: github.event.pull_request.head.repo.full_name == github.repository
+        if: >-
+          github.event_name != 'pull_request' ||
+          github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: cloudflare-preview-site

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,4 +1,4 @@
-name: Deploy pull request preview
+name: Deploy Cloudflare previews
 
 on:
   workflow_run:
@@ -12,33 +12,63 @@ permissions:
   pull-requests: read
 
 concurrency:
-  group: pr-preview-${{ github.event.workflow_run.head_branch }}
+  group: cloudflare-preview-${{ github.event.workflow_run.event == 'pull_request' && 'pr' || 'branch' }}-${{ github.event.workflow_run.head_branch }}
   cancel-in-progress: true
 
 jobs:
   deploy:
-    name: Publish trusted PR artifact
+    name: Publish trusted artifact
     if: >-
-      github.event.workflow_run.event == 'pull_request' &&
       github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.head_repository.full_name == github.repository
+      github.event.workflow_run.head_repository.full_name == github.repository &&
+      (
+        github.event.workflow_run.event == 'pull_request' ||
+        (
+          (
+            github.event.workflow_run.event == 'push' ||
+            github.event.workflow_run.event == 'workflow_dispatch'
+          ) &&
+          github.event.workflow_run.head_branch == 'dev'
+        )
+      )
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     environment:
       name: cloudflare-pages
 
     env:
+      RUN_EVENT: ${{ github.event.workflow_run.event }}
       HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
       TRIGGER_RUN_ID: ${{ github.event.workflow_run.id }}
       CLOUDFLARE_PAGES_PROJECT: ${{ vars.CLOUDFLARE_PAGES_PROJECT }}
 
     steps:
-      - name: Resolve the current pull request
-        id: pull_request
+      - name: Resolve the current deployment target
+        id: target
         env:
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
           GH_TOKEN: ${{ github.token }}
         run: |
+          if [[ "${RUN_EVENT}" != "pull_request" ]]; then
+            current_sha="$(gh api \
+              "repos/${GITHUB_REPOSITORY}/git/ref/heads/dev" \
+              --jq '.object.sha')"
+            if [[ "${current_sha}" != "${HEAD_SHA}" ]]; then
+              echo "The dev branch has advanced from ${HEAD_SHA} to ${current_sha}; skipping stale handoff."
+              echo "deploy=false" >>"${GITHUB_OUTPUT}"
+              exit 0
+            fi
+            {
+              echo "deploy=true"
+              echo "branch=dev"
+              echo "environment=cloudflare-pages-dev"
+              echo "url=https://dev.newshoes.gg/"
+              echo "transient=false"
+              echo "description=Cloudflare Pages dev branch"
+            } >>"${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
           pulls="$(gh api \
             -H "Accept: application/vnd.github+json" \
             "repos/${GITHUB_REPOSITORY}/commits/${HEAD_SHA}/pulls")"
@@ -60,13 +90,17 @@ jobs:
             exit 0
           fi
           pr_number="$(jq -r '.number' <<<"${match}")"
-          preview_url="https://pr-${pr_number}.${CLOUDFLARE_PAGES_PROJECT}.pages.dev"
-          echo "deploy=true" >>"${GITHUB_OUTPUT}"
-          echo "number=${pr_number}" >>"${GITHUB_OUTPUT}"
-          echo "url=${preview_url}" >>"${GITHUB_OUTPUT}"
+          {
+            echo "deploy=true"
+            echo "branch=pr-${pr_number}"
+            echo "environment=pr-${pr_number}"
+            echo "url=https://pr-${pr_number}.${CLOUDFLARE_PAGES_PROJECT}.pages.dev"
+            echo "transient=true"
+            echo "description=Cloudflare Pages pull request preview"
+          } >>"${GITHUB_OUTPUT}"
 
       - name: Validate deployment configuration
-        if: steps.pull_request.outputs.deploy == 'true'
+        if: steps.target.outputs.deploy == 'true'
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -76,7 +110,7 @@ jobs:
           test -n "${CLOUDFLARE_PAGES_PROJECT}" || { echo "CLOUDFLARE_PAGES_PROJECT is not configured"; exit 1; }
 
       - name: Download audited preview artifact
-        if: steps.pull_request.outputs.deploy == 'true'
+        if: steps.target.outputs.deploy == 'true'
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: cloudflare-preview-site
@@ -85,34 +119,38 @@ jobs:
           run-id: ${{ env.TRIGGER_RUN_ID }}
 
       - name: Set up Node 22
-        if: steps.pull_request.outputs.deploy == 'true'
+        if: steps.target.outputs.deploy == 'true'
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "22"
 
       - name: Install pinned deployment client
-        if: steps.pull_request.outputs.deploy == 'true'
+        if: steps.target.outputs.deploy == 'true'
         run: npm install --global --ignore-scripts wrangler@4.110.0
 
       - name: Create GitHub deployment
-        if: steps.pull_request.outputs.deploy == 'true'
+        if: steps.target.outputs.deploy == 'true'
         id: deployment
         env:
+          DEPLOYMENT_DESCRIPTION: ${{ steps.target.outputs.description }}
+          DEPLOYMENT_ENVIRONMENT: ${{ steps.target.outputs.environment }}
+          DEPLOYMENT_TRANSIENT: ${{ steps.target.outputs.transient }}
+          DEPLOYMENT_URL: ${{ steps.target.outputs.url }}
           GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ steps.pull_request.outputs.number }}
-          PREVIEW_URL: ${{ steps.pull_request.outputs.url }}
         run: |
           deployment_id="$(jq -n \
             --arg ref "${HEAD_SHA}" \
-            --arg environment "pr-${PR_NUMBER}" \
+            --arg environment "${DEPLOYMENT_ENVIRONMENT}" \
+            --arg description "${DEPLOYMENT_DESCRIPTION}" \
+            --argjson transient "${DEPLOYMENT_TRANSIENT}" \
             '{
               ref: $ref,
               environment: $environment,
               auto_merge: false,
               required_contexts: [],
-              transient_environment: true,
+              transient_environment: $transient,
               production_environment: false,
-              description: "Cloudflare Pages pull request preview"
+              description: $description
             }' | gh api \
               --method POST \
               "repos/${GITHUB_REPOSITORY}/deployments" \
@@ -120,7 +158,7 @@ jobs:
               --jq '.id')"
           jq -n \
             --arg state "in_progress" \
-            --arg url "${PREVIEW_URL}" \
+            --arg url "${DEPLOYMENT_URL}" \
             --arg log_url "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
             '{state: $state, environment_url: $url, log_url: $log_url}' | gh api \
               --method POST \
@@ -128,29 +166,29 @@ jobs:
               --input - >/dev/null
           echo "id=${deployment_id}" >>"${GITHUB_OUTPUT}"
 
-      - name: Deploy stable Cloudflare preview
-        if: steps.pull_request.outputs.deploy == 'true'
+      - name: Deploy stable Cloudflare branch
+        if: steps.target.outputs.deploy == 'true'
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          PR_NUMBER: ${{ steps.pull_request.outputs.number }}
+          DEPLOYMENT_BRANCH: ${{ steps.target.outputs.branch }}
         run: >-
           wrangler pages deploy cloudflare-dist
           --project-name="${CLOUDFLARE_PAGES_PROJECT}"
-          --branch="pr-${PR_NUMBER}"
+          --branch="${DEPLOYMENT_BRANCH}"
           --commit-hash="${HEAD_SHA}"
           --commit-dirty=false
 
       - name: Mark GitHub deployment successful
-        if: steps.pull_request.outputs.deploy == 'true' && success()
+        if: steps.target.outputs.deploy == 'true' && success()
         env:
           DEPLOYMENT_ID: ${{ steps.deployment.outputs.id }}
+          DEPLOYMENT_URL: ${{ steps.target.outputs.url }}
           GH_TOKEN: ${{ github.token }}
-          PREVIEW_URL: ${{ steps.pull_request.outputs.url }}
         run: |
           jq -n \
             --arg state "success" \
-            --arg url "${PREVIEW_URL}" \
+            --arg url "${DEPLOYMENT_URL}" \
             --arg log_url "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
             '{state: $state, environment_url: $url, log_url: $log_url, auto_inactive: true}' | gh api \
               --method POST \
@@ -161,12 +199,12 @@ jobs:
         if: failure() && steps.deployment.outputs.id != ''
         env:
           DEPLOYMENT_ID: ${{ steps.deployment.outputs.id }}
+          DEPLOYMENT_URL: ${{ steps.target.outputs.url }}
           GH_TOKEN: ${{ github.token }}
-          PREVIEW_URL: ${{ steps.pull_request.outputs.url }}
         run: |
           jq -n \
             --arg state "failure" \
-            --arg url "${PREVIEW_URL}" \
+            --arg url "${DEPLOYMENT_URL}" \
             --arg log_url "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
             '{state: $state, environment_url: $url, log_url: $log_url}' | gh api \
               --method POST \

--- a/WebAssembly/CLOUDFLARE.md
+++ b/WebAssembly/CLOUDFLARE.md
@@ -41,6 +41,50 @@ publishes is tied to the pull request head SHA. Preview sites remain asset-free
 and never contain retail game data. Cloudflare marks preview deployments
 `noindex` automatically.
 
+## Development branch deployment
+
+Every push to the persistent `dev` branch runs the same release build, artifact
+guards, and browser deployment proof as a pull request. After those checks
+succeed, the default-branch `pr-preview.yml` workflow downloads the audited
+artifact and publishes it as Cloudflare Pages branch `dev`. It rejects a
+handoff when `dev` has advanced to a newer commit, so an older build cannot
+replace the current development site.
+
+The credentialed job still runs from the repository's default `main` branch and
+uses the existing `cloudflare-pages` environment. Do not grant the unprotected
+`dev` branch direct access to that environment or duplicate its secrets in a
+development-branch workflow. GitHub records the result as the non-production
+`cloudflare-pages-dev` deployment at:
+
+```text
+https://dev.newshoes.gg/
+```
+
+Both halves of the handoff must be present before the first deployment: merge
+the build trigger into `dev`, then promote the trusted deployment workflow to
+`main` through the normal release flow. After that promotion, either the next
+push to `dev` or a one-time manual run of **Pull request CI** from `dev` creates
+the first branch deployment. Later pushes deploy automatically.
+
+Cloudflare first exposes the branch at the stable
+`https://dev.<project>.pages.dev/` alias. Complete the custom-domain setup once,
+after the first successful `dev` deployment:
+
+1. In the existing Pages project, add `dev.newshoes.gg` under **Custom
+   domains** and activate it.
+2. In Cloudflare DNS, change the resulting `dev` CNAME target from
+   `<project>.pages.dev` to `dev.<project>.pages.dev`.
+3. Keep the CNAME proxied. An unproxied record sends the custom hostname to the
+   production branch instead of the `dev` alias.
+4. Open `https://dev.newshoes.gg/` in a fresh profile and confirm the first
+   response includes COOP/COEP, `crossOriginIsolated` is true, and the launcher
+   shows the `dev` commit reported by the GitHub deployment.
+
+The development hostname is a separate browser origin from `newshoes.gg`.
+Retail files installed into origin-private storage on one hostname are not
+available on the other. Cloudflare adds `X-Robots-Tag: noindex` to preview
+deployments, including the `dev` branch.
+
 ## One-time Cloudflare setup
 
 1. Create a **Pages / Direct Upload** project. Record its project name.

--- a/WebAssembly/tools/check_pages_sources.mjs
+++ b/WebAssembly/tools/check_pages_sources.mjs
@@ -91,14 +91,16 @@ for (const workflow of workflowPaths) {
   if (!document || typeof document !== "object") throw new Error(`Invalid YAML document: ${workflow}`);
 }
 
-const pullRequestWorkflow = await readFile(resolve(repoRoot, ".github/workflows/ci.yml"), "utf8");
+const buildWorkflow = await readFile(resolve(repoRoot, ".github/workflows/ci.yml"), "utf8");
 for (const contract of [
+  "branches: [dev]",
   "npm run test:cloudflare-artifact-guard",
   "npm run test:cloudflare-deployment",
   "name: cloudflare-preview-site",
+  "github.event_name != 'pull_request'",
   "github.event.pull_request.head.repo.full_name == github.repository",
 ]) {
-  if (!pullRequestWorkflow.includes(contract)) throw new Error(`Pull request preview handoff missing: ${contract}`);
+  if (!buildWorkflow.includes(contract)) throw new Error(`Trusted Cloudflare artifact handoff missing: ${contract}`);
 }
 
 const previewWorkflow = await readFile(resolve(repoRoot, ".github/workflows/pr-preview.yml"), "utf8");
@@ -108,11 +110,24 @@ for (const contract of [
   "github.event.workflow_run.conclusion == 'success'",
   "name: cloudflare-pages",
   "name: cloudflare-preview-site",
-  '--branch="pr-${PR_NUMBER}"',
   '.base.ref == $base or .base.ref == "dev"',
-  "transient_environment: true",
+  "github.event.workflow_run.event == 'push'",
+  "github.event.workflow_run.event == 'workflow_dispatch'",
+  "github.event.workflow_run.head_branch == 'dev'",
+  '"repos/${GITHUB_REPOSITORY}/git/ref/heads/dev"',
+  'https://dev.newshoes.gg/',
+  'echo "branch=dev"',
+  'echo "environment=cloudflare-pages-dev"',
+  'echo "transient=false"',
+  'echo "branch=pr-${pr_number}"',
+  'echo "environment=pr-${pr_number}"',
+  'echo "transient=true"',
+  '--argjson transient "${DEPLOYMENT_TRANSIENT}"',
+  "transient_environment: $transient",
+  "production_environment: false",
+  '--branch="${DEPLOYMENT_BRANCH}"',
 ]) {
-  if (!previewWorkflow.includes(contract)) throw new Error(`Trusted preview deployment contract missing: ${contract}`);
+  if (!previewWorkflow.includes(contract)) throw new Error(`Trusted Cloudflare deployment contract missing: ${contract}`);
 }
 
 const serviceWorker = await readFile(resolve(wasmRoot, "pages/coi-serviceworker.js"), "utf8");


### PR DESCRIPTION
## Summary

- run the audited release build and browser deployment proof on every push to `dev`;
- extend the default-branch Cloudflare handoff to publish current `dev` artifacts at the stable `dev` branch alias without exposing deployment credentials to `dev` code;
- reject stale handoffs, preserve existing PR previews, and record a non-production `cloudflare-pages-dev` GitHub deployment at `https://dev.newshoes.gg/`;
- document the release-order and one-time proxied custom-domain setup.

## Why

The existing Cloudflare workflow deploys only `main`, while PR previews already use a trusted artifact handoff through a credentialed workflow on `main`. Reusing that boundary gives `dev` automatic deployment without granting the currently unprotected `dev` branch access to the production Cloudflare token.

## Verification

- `npm --prefix WebAssembly run check:pages`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/ci.yml .github/workflows/pr-preview.yml`
- resolver exercised against the current `dev` SHA, a stale SHA, a manual `dev` dispatch, and live PR #46
- `git diff --check`

## Activation

After this lands in `dev`, promote the trusted workflow to `main` through the normal release flow. Run the CI workflow from `dev` once (or wait for the next push), then attach `dev.newshoes.gg` to the proxied `dev.<project>.pages.dev` branch alias as documented in `WebAssembly/CLOUDFLARE.md`.

Refs #48

Agent-Model: OpenAI gpt-5.6-sol
