### PR TITLE
Smooth frame stalls in large skirmish replays

### DIFF
--- a/GeneralsMD/Code/GameEngine/Include/Common/Recorder.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/Recorder.h
@@ -78,6 +78,7 @@ public:
 
 public:
 	void handleCRCMessage(UnsignedInt newCRC, Int playerIndex, Bool fromPlayback);
+	Bool sawPlaybackCRCMismatch();
 protected:
 	CRCInfo *m_crcInfo;
 public:

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/AIPathfind.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/AIPathfind.h
@@ -209,6 +209,7 @@ class PathfindCell;
 class PathfindCellInfo
 {
 	friend class PathfindCell;
+	friend class Pathfinder;
 public:
 	static void allocateCellInfos(void);
 	static void releaseCellInfos(void);
@@ -227,6 +228,7 @@ protected:
 	PathfindCell *m_cell;															///< Cell this info belongs to currently.
 
 	UnsignedShort m_totalCost, m_costSoFar;	///< cost estimates for A* search
+	UnsignedShort m_openBucketCost;
 
 	/// have to include cell's coordinates, since cells are often accessed via pointer only
 	ICoord2D m_pos;
@@ -236,7 +238,6 @@ protected:
 	ObjectID m_goalAircraftID; ///< The objectID of the aircraft whose goal this is.
 
 	ObjectID m_obstacleID;	///< the object ID who overlaps this cell
-	
 	UnsignedInt m_isFree:1;
 	UnsignedInt m_blockedByAlly:1;///< True if this cell is blocked by an allied unit.
 	UnsignedInt m_obstacleIsFence:1;///< True if occupied by a fence.
@@ -254,6 +255,7 @@ protected:
  */
 class PathfindCell
 {
+	friend class Pathfinder;
 public:
 
 	enum CellType
@@ -348,6 +350,14 @@ public:
 	Bool allocateInfo(const ICoord2D &pos);
 	void releaseInfo(void);
 	Bool hasInfo(void) const {return m_info!=NULL;}
+	Bool getCachedMovementCheck(UnsignedInt generation, PathfindLayerEnum layer, Bool &passable,
+		Int &allyFixedCount, Bool &allyMoving, Bool &allyGoal, Bool &enemyFixed) const;
+	void cacheMovementCheck(UnsignedInt generation, PathfindLayerEnum layer, Bool passable,
+		Int allyFixedCount, Bool allyMoving, Bool allyGoal, Bool enemyFixed);
+	Bool getCachedLinePassability(UnsignedInt generation, Bool &passable) const;
+	void cacheLinePassability(UnsignedInt generation, Bool passable);
+	Bool getCachedClearDiameter(UnsignedInt generation, Int &clearDiameter) const;
+	void cacheClearDiameter(UnsignedInt generation, Int clearDiameter);
 	zoneStorageType getZone(void) const {return m_zone;}
 	void setZone(zoneStorageType zone) {m_zone = zone;}
 	void setGoalUnit(ObjectID unit, const ICoord2D &pos );
@@ -375,6 +385,12 @@ private:
 	UnsignedByte m_flags:4;			///< what type of units are in or moving through this cell.
 	UnsignedByte m_connectsToLayer:4;	///< This cell can pathfind onto this layer, if > LAYER_TOP.
   UnsignedByte m_layer:4;					 ///< Layer of this cell.
+	// Scratch results are tagged per search, so no simulation state or snapshot
+	// data depends on them.
+	UnsignedInt m_pathfindCacheGeneration;
+	UnsignedShort m_clearDiameterCacheValue;
+	UnsignedByte m_pathfindCacheFlags;
+	UnsignedByte m_pathfindCacheLayer;
 };
 
 typedef PathfindCell *PathfindCellP;
@@ -756,6 +772,12 @@ protected:
 	void adjustCoordToCell(Int cellX, Int cellY, Bool centerInCell, Coord3D &pos, PathfindLayerEnum layer);
 	Bool checkDestination(const Object *obj, Int cellX, Int cellY, PathfindLayerEnum layer, Int iRadius, Bool centerInCell);
 	Bool checkForMovement(const Object *obj, TCheckMovementInfo &info);
+	void startFastOpenQueue(PathfindCell *startCell);
+	PathfindCell *popFastOpenQueue(void);
+	void pushFastOpenQueue(PathfindCell *cell);
+	void removeFastOpenQueue(PathfindCell *cell);
+	Int cachedClearCellForDiameter(UnsignedInt generation, Bool crusher, Int cellX, Int cellY,
+		PathfindLayerEnum layer, Int pathDiameter);
 	Bool segmentIntersectsTallBuilding(const PathNode *curNode, PathNode *nextNode,  
 		ObjectID ignoreBuilding, Coord3D *insertPos1, Coord3D *insertPos2, Coord3D *insertPos3);	///< Return true if the straight line between the given points intersects a tall building.
 	Bool circleClipsTallBuilding(const Coord3D *from, const Coord3D *to, Real radius, ObjectID ignoreBuilding, Coord3D *adjustTo);	///< Return true if the circle at the end of the line between the given points intersects a tall building.
@@ -764,7 +786,8 @@ protected:
 	Int examineNeighboringCells(PathfindCell *parentCell, PathfindCell *goalCell,
 										const LocomotorSet& locomotorSet, Bool isHumanPlayer, 
 										Bool centerInCell, Int radius, const ICoord2D &startCellNdx,
-										const Object *obj, Int attackDistance);
+										const Object *obj, Int attackDistance,
+										UnsignedInt movementCacheGeneration = 0);
 
  	Bool pathDestination( Object *obj, const LocomotorSet& locomotorSet, Coord3D *dest, 
 		PathfindLayerEnum layer, const Coord3D *groupDest);	///< Checks cost between given locations
@@ -786,6 +809,9 @@ protected:
 
 	Int iterateCellsAlongLine(const ICoord2D &start, const ICoord2D &end, 
 		PathfindLayerEnum layer, CellAlongLineProc proc, void* userData);
+	Int examineCellsAlongLine(const ICoord2D &start, const ICoord2D &end,
+		PathfindLayerEnum layer, void *userData);
+	Int examineLineCell(PathfindCell *from, PathfindCell *to, Int toX, Int toY, void *userData);
 
 	static Int linePassableCallback(Pathfinder* pathfinder, PathfindCell* from, PathfindCell* to, Int to_x, Int to_y, void* userData);
 	static Int groundPathPassableCallback(Pathfinder* pathfinder, PathfindCell* from, PathfindCell* to, Int to_x, Int to_y, void* userData);
@@ -869,6 +895,12 @@ private:
 	Int						m_queuePRHead;
 	Int						m_queuePRTail;
 	Int						m_cumulativeCellsAllocated;
+	UnsignedInt	m_pathfindCacheGeneration;
+	PathfindCell **m_fastOpenBucketHeads;
+	PathfindCell **m_fastOpenBucketTails;
+	UnsignedInt m_fastOpenCount;
+	UnsignedInt m_fastOpenMinimumCost;
+	Bool m_fastOpenQueueActive;
 };
 
 

--- a/GeneralsMD/Code/GameEngine/Source/Common/GlobalData.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/GlobalData.cpp
@@ -836,7 +836,14 @@ GlobalData::GlobalData()
 	m_stealthFriendlyOpacity = 0.5f;
 	m_defaultOcclusionDelay = LOGICFRAMES_PER_SECOND * 3;	//default to 3 seconds
 
+#ifdef __EMSCRIPTEN__
+	// Browser asset reads and W3D model creation are synchronous. Pay their
+	// first-use cost while the match loading screen is active instead of on a
+	// live simulation frame when a faction constructs a model for the first time.
+	m_preloadAssets = TRUE;
+#else
 	m_preloadAssets = FALSE;
+#endif
 	m_preloadEverything = FALSE;
 	m_preloadReport = FALSE;
 

--- a/GeneralsMD/Code/GameEngine/Source/Common/Recorder.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/Recorder.cpp
@@ -1088,6 +1088,11 @@ void RecorderClass::handleCRCMessage(UnsignedInt newCRC, Int playerIndex, Bool f
 	//DEBUG_LOG(("RecorderClass::handleCRCMessage() - Skipping CRC of %8.8X from %d (our index is %d)\n", newCRC, playerIndex, localPlayerIndex));
 }
 
+Bool RecorderClass::sawPlaybackCRCMismatch()
+{
+	return m_crcInfo != NULL && m_crcInfo->sawCRCMismatch();
+}
+
 /**
  * Return true if this version of the file is the same as our version of the game
  */

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
@@ -1158,6 +1158,7 @@ PathfindCellInfo *PathfindCellInfo::getACellInfo(PathfindCell *cell,const ICoord
 		info->m_pathParent = NULL;
 		info->m_costSoFar = 0;		
 		info->m_totalCost = 0;
+		info->m_openBucketCost = 0;
 		info->m_open = 0;
 		info->m_closed = 0;
 		info->m_obstacleID = INVALID_ID;
@@ -1218,6 +1219,10 @@ void PathfindCell::reset( )
 	m_zone = 0;
 	m_aircraftGoal = false;
 	m_pinched = false;
+	m_pathfindCacheGeneration = 0;
+	m_pathfindCacheFlags = 0;
+	m_pathfindCacheLayer = LAYER_INVALID;
+	m_clearDiameterCacheValue = 0;
 	if (m_info) {
 		m_info->m_obstacleID = INVALID_ID;
 		PathfindCellInfo::releaseACellInfo(m_info);
@@ -1226,6 +1231,107 @@ void PathfindCell::reset( )
 	m_connectsToLayer = LAYER_INVALID;
 	m_layer = LAYER_GROUND;
 	
+}
+
+enum
+{
+	PATHFIND_CACHE_LAYER_MASK = 0x0f,
+	PATHFIND_CACHE_MOVEMENT_PASSABLE = 0x01,
+	PATHFIND_CACHE_ALLY_MOVING = 0x02,
+	PATHFIND_CACHE_ALLY_GOAL = 0x04,
+	PATHFIND_CACHE_ENEMY_FIXED = 0x08,
+	PATHFIND_CACHE_ALLY_FIXED = 0x10,
+	PATHFIND_CACHE_LINE_VALID = 0x20,
+	PATHFIND_CACHE_LINE_PASSABLE = 0x40,
+	PATHFIND_CACHE_MOVEMENT_VALID = 0x80,
+	PATHFIND_CACHE_CLEAR_VALID = 0x80
+};
+
+Bool PathfindCell::getCachedMovementCheck(UnsignedInt generation, PathfindLayerEnum layer, Bool &passable,
+	Int &allyFixedCount, Bool &allyMoving, Bool &allyGoal, Bool &enemyFixed) const
+{
+	if (generation == 0 || m_pathfindCacheGeneration != generation
+		|| (m_pathfindCacheLayer & PATHFIND_CACHE_LAYER_MASK) != layer
+		|| (m_pathfindCacheFlags & PATHFIND_CACHE_MOVEMENT_VALID) == 0) {
+		return false;
+	}
+	passable = (m_pathfindCacheFlags & PATHFIND_CACHE_MOVEMENT_PASSABLE) != 0;
+	allyMoving = (m_pathfindCacheFlags & PATHFIND_CACHE_ALLY_MOVING) != 0;
+	allyGoal = (m_pathfindCacheFlags & PATHFIND_CACHE_ALLY_GOAL) != 0;
+	enemyFixed = (m_pathfindCacheFlags & PATHFIND_CACHE_ENEMY_FIXED) != 0;
+	allyFixedCount = (m_pathfindCacheFlags & PATHFIND_CACHE_ALLY_FIXED) != 0 ? 1 : 0;
+	return true;
+}
+
+void PathfindCell::cacheMovementCheck(UnsignedInt generation, PathfindLayerEnum layer, Bool passable,
+	Int allyFixedCount, Bool allyMoving, Bool allyGoal, Bool enemyFixed)
+{
+	if (generation == 0) {
+		return;
+	}
+	const Bool sameGeneration = m_pathfindCacheGeneration == generation;
+	UnsignedByte lineFlags = sameGeneration
+		? m_pathfindCacheFlags & (PATHFIND_CACHE_LINE_VALID | PATHFIND_CACHE_LINE_PASSABLE) : 0;
+	UnsignedByte clearValid = sameGeneration ? m_pathfindCacheLayer & PATHFIND_CACHE_CLEAR_VALID : 0;
+	m_pathfindCacheGeneration = generation;
+	m_pathfindCacheLayer = clearValid | (layer & PATHFIND_CACHE_LAYER_MASK);
+	m_pathfindCacheFlags = lineFlags | PATHFIND_CACHE_MOVEMENT_VALID
+		| (passable ? PATHFIND_CACHE_MOVEMENT_PASSABLE : 0)
+		| (allyMoving ? PATHFIND_CACHE_ALLY_MOVING : 0)
+		| (allyGoal ? PATHFIND_CACHE_ALLY_GOAL : 0)
+		| (enemyFixed ? PATHFIND_CACHE_ENEMY_FIXED : 0)
+		| (allyFixedCount > 0 ? PATHFIND_CACHE_ALLY_FIXED : 0);
+}
+
+Bool PathfindCell::getCachedLinePassability(UnsignedInt generation, Bool &passable) const
+{
+	if (generation == 0 || m_pathfindCacheGeneration != generation
+		|| (m_pathfindCacheFlags & PATHFIND_CACHE_LINE_VALID) == 0) {
+		return false;
+	}
+	passable = (m_pathfindCacheFlags & PATHFIND_CACHE_LINE_PASSABLE) != 0;
+	return true;
+}
+
+void PathfindCell::cacheLinePassability(UnsignedInt generation, Bool passable)
+{
+	if (generation == 0) {
+		return;
+	}
+	if (m_pathfindCacheGeneration != generation) {
+		m_pathfindCacheFlags = 0;
+		m_pathfindCacheLayer = LAYER_INVALID;
+	}
+	m_pathfindCacheGeneration = generation;
+	m_pathfindCacheFlags = (m_pathfindCacheFlags
+		& ~(PATHFIND_CACHE_LINE_VALID | PATHFIND_CACHE_LINE_PASSABLE))
+		| PATHFIND_CACHE_LINE_VALID | (passable ? PATHFIND_CACHE_LINE_PASSABLE : 0);
+}
+
+Bool PathfindCell::getCachedClearDiameter(UnsignedInt generation, Int &clearDiameter) const
+{
+	if (generation == 0 || m_pathfindCacheGeneration != generation
+		|| (m_pathfindCacheLayer & PATHFIND_CACHE_CLEAR_VALID) == 0) {
+		return false;
+	}
+	clearDiameter = m_clearDiameterCacheValue;
+	return true;
+}
+
+void PathfindCell::cacheClearDiameter(UnsignedInt generation, Int clearDiameter)
+{
+	if (generation == 0) {
+		return;
+	}
+	if (m_pathfindCacheGeneration != generation) {
+		m_pathfindCacheFlags = 0;
+		m_pathfindCacheLayer = LAYER_INVALID;
+	}
+	DEBUG_ASSERTCRASH(clearDiameter >= 0 && clearDiameter <= 0xffff,
+		("Clear path diameter does not fit in the pathfind cache."));
+	m_pathfindCacheGeneration = generation;
+	m_pathfindCacheLayer |= PATHFIND_CACHE_CLEAR_VALID;
+	m_clearDiameterCacheValue = static_cast<UnsignedShort>(clearDiameter);
 }
 
 /**
@@ -1869,6 +1975,43 @@ static void __fastcall resolveBlockZones(Int srcZone, Int targetZone, zoneStorag
 	}
 }
 
+static zoneStorageType findZoneRoot(zoneStorageType *zoneEquivalency, Int zone)
+{
+	Int root = zone;
+	while (zoneEquivalency[root] != root) {
+		root = zoneEquivalency[root];
+	}
+	while (zoneEquivalency[zone] != zone) {
+		Int parent = zoneEquivalency[zone];
+		zoneEquivalency[zone] = static_cast<zoneStorageType>(root);
+		zone = parent;
+	}
+	return static_cast<zoneStorageType>(root);
+}
+
+static void resolveZonesFast(Int srcZone, Int targetZone, zoneStorageType *zoneEquivalency, Int sizeOfZE)
+{
+	DEBUG_ASSERTCRASH(srcZone > 0 && targetZone > 0 && srcZone < sizeOfZE && targetZone < sizeOfZE,
+		("Bad fast zone resolution."));
+	zoneStorageType srcRoot = findZoneRoot(zoneEquivalency, srcZone);
+	zoneStorageType targetRoot = findZoneRoot(zoneEquivalency, targetZone);
+	if (srcRoot == targetRoot) {
+		return;
+	}
+	if (targetRoot < srcRoot) {
+		zoneEquivalency[srcRoot] = targetRoot;
+	} else {
+		zoneEquivalency[targetRoot] = srcRoot;
+	}
+}
+
+static void materializeZoneRoots(zoneStorageType *zoneEquivalency, Int sizeOfZE)
+{
+	for (Int i = 0; i < sizeOfZE; i++) {
+		zoneEquivalency[i] = findZoneRoot(zoneEquivalency, i);
+	}
+}
+
 static void __fastcall resolveZones(Int srcZone, Int targetZone, zoneStorageType *zoneEquivalency, Int sizeOfZE)
 {
 	Int i;
@@ -1915,12 +2058,13 @@ static void flattenZones(zoneStorageType *zoneArray, zoneStorageType *zoneHierar
 #endif
 }
 
-inline void applyZone(PathfindCell &targetCell, const PathfindCell &sourceCell, zoneStorageType *zoneEquivalency, Int sizeOfZE)
+inline void applyZoneFast(PathfindCell &targetCell, const PathfindCell &sourceCell,
+	zoneStorageType *zoneEquivalency, Int sizeOfZE)
 {
 	DEBUG_ASSERTCRASH(sourceCell.getZone()!=0, ("Unset source zone."));
-	Int srcZone = zoneEquivalency[sourceCell.getZone()];
+	Int srcZone = findZoneRoot(zoneEquivalency, sourceCell.getZone());
 	//DEBUG_ASSERTCRASH(srcZone!=0, ("Bad zone equivalency zone."));
-	Int targetZone = zoneEquivalency[targetCell.getZone()];
+	Int targetZone = findZoneRoot(zoneEquivalency, targetCell.getZone());
 
 	if (targetZone == 0) {
 		targetCell.setZone(srcZone);
@@ -1929,7 +2073,7 @@ inline void applyZone(PathfindCell &targetCell, const PathfindCell &sourceCell, 
 	if (targetZone == srcZone) {
 		return; // already match.
 	}
-	resolveZones(srcZone, targetZone, zoneEquivalency, sizeOfZE);
+	resolveZonesFast(srcZone, targetZone, zoneEquivalency, sizeOfZE);
 
 }
 
@@ -2351,12 +2495,12 @@ void PathfindZoneManager::calculateZones( PathfindCell **map, PathfindLayer laye
 
 					if (i>bounds.lo.x) {
 						if (map[i][j].getType() == map[i-1][j].getType()) {
-							applyZone(map[i][j], map[i-1][j], zoneEquivalency, m_maxZone);
+							applyZoneFast(map[i][j], map[i-1][j], zoneEquivalency, m_maxZone);
 						}
 					}
 					if (j>bounds.lo.y) {
 						if (map[i][j].getType() == map[i][j-1].getType()) {
-							applyZone(map[i][j], map[i][j-1], zoneEquivalency, m_maxZone);
+							applyZoneFast(map[i][j], map[i][j-1], zoneEquivalency, m_maxZone);
 						}
 					}
 					if (cell->getZone()==0) {
@@ -2378,6 +2522,7 @@ void PathfindZoneManager::calculateZones( PathfindCell **map, PathfindLayer laye
 	}
 
 	Int totalZones = m_maxZone;
+	materializeZoneRoots(zoneEquivalency, totalZones);
 //	if (totalZones>maxZones/2) {
 //		DEBUG_LOG(("Max zones %d\n", m_maxZone));
 //	}
@@ -2654,7 +2799,7 @@ void PathfindZoneManager::calculateZones( PathfindCell **map, PathfindLayer laye
 				(r_thisCell.getType() == PathfindCell::CELL_CLEAR) ) 
       {
 				PathfindLayer *layer = layers + r_thisCell.getConnectLayer();
-				resolveZones(r_thisCell.getZone(), layer->getZone(), m_hierarchicalZones, maxZone);
+				resolveZonesFast(r_thisCell.getZone(), layer->getZone(), m_hierarchicalZones, maxZone);
 			}
 
 			if ( i > globalBounds.lo.x && r_thisCell.getZone() != map[i-1][j].getZone() ) 
@@ -2662,31 +2807,31 @@ void PathfindZoneManager::calculateZones( PathfindCell **map, PathfindLayer laye
         const PathfindCell &r_leftCell = map[i-1][j];
 
 				if (r_thisCell.getType() == r_leftCell.getType()) 
-					applyZone(r_thisCell, r_leftCell, m_hierarchicalZones, maxZone);//if this is true, skip all the ones below
+					applyZoneFast(r_thisCell, r_leftCell, m_hierarchicalZones, maxZone);//if this is true, skip all the ones below
         else
         {
           Bool notTerrainOrCrusher = TRUE; // if this is false, skip the if-else-ladder below 
 
           if (terrain(r_thisCell, r_leftCell)) 
           {
-					  applyZone(r_thisCell, r_leftCell, m_terrainZones, maxZone);
+					  applyZoneFast(r_thisCell, r_leftCell, m_terrainZones, maxZone);
             notTerrainOrCrusher = FALSE;
           }
 
           if (crusherGround(r_thisCell, r_leftCell)) 
           {
-					  applyZone(r_thisCell, r_leftCell, m_crusherZones, maxZone); 
+					  applyZoneFast(r_thisCell, r_leftCell, m_crusherZones, maxZone);
             notTerrainOrCrusher = FALSE;
           }
 
           if ( notTerrainOrCrusher )
           {
             if (waterGround(r_thisCell, r_leftCell)) 
-					    applyZone(r_thisCell, r_leftCell, m_groundWaterZones, maxZone);
+					    applyZoneFast(r_thisCell, r_leftCell, m_groundWaterZones, maxZone);
             else if (groundRubble(r_thisCell, r_leftCell)) 
-					    applyZone(r_thisCell, r_leftCell, m_groundRubbleZones, maxZone);
+					    applyZoneFast(r_thisCell, r_leftCell, m_groundRubbleZones, maxZone);
             else if (groundCliff(r_thisCell, r_leftCell)) 
-					    applyZone(r_thisCell, r_leftCell, m_groundCliffZones, maxZone);
+					    applyZoneFast(r_thisCell, r_leftCell, m_groundCliffZones, maxZone);
           }
 
         }
@@ -2698,29 +2843,29 @@ void PathfindZoneManager::calculateZones( PathfindCell **map, PathfindLayer laye
         const PathfindCell &r_topCell = map[i][j-1];
 
         if (r_thisCell.getType() == r_topCell.getType()) 
-					applyZone(r_thisCell, r_topCell, m_hierarchicalZones, maxZone);
+					applyZoneFast(r_thisCell, r_topCell, m_hierarchicalZones, maxZone);
         else
         {
           Bool notTerrainOrCrusher = TRUE; // if this is false, skip the if-else-ladder below 
 
           if (terrain(r_thisCell, r_topCell)) 
           {
-            applyZone(r_thisCell, r_topCell, m_terrainZones, maxZone);
+			applyZoneFast(r_thisCell, r_topCell, m_terrainZones, maxZone);
             notTerrainOrCrusher = FALSE;
           }
 
           if (crusherGround(r_thisCell, r_topCell)) 
           {
-					  applyZone(r_thisCell, r_topCell, m_crusherZones, maxZone);
+					  applyZoneFast(r_thisCell, r_topCell, m_crusherZones, maxZone);
             notTerrainOrCrusher = FALSE;
           }
 
           if (waterGround(r_thisCell,r_topCell)) 
-					  applyZone(r_thisCell, r_topCell, m_groundWaterZones, maxZone);
+					  applyZoneFast(r_thisCell, r_topCell, m_groundWaterZones, maxZone);
           else if (groundRubble(r_thisCell, r_topCell)) 
-					  applyZone(r_thisCell, r_topCell, m_groundRubbleZones, maxZone);
+					  applyZoneFast(r_thisCell, r_topCell, m_groundRubbleZones, maxZone);
           else if (groundCliff(r_thisCell,r_topCell)) 
-					  applyZone(r_thisCell, r_topCell, m_groundCliffZones, maxZone);
+					  applyZoneFast(r_thisCell, r_topCell, m_groundCliffZones, maxZone);
 
         }
 
@@ -2741,6 +2886,12 @@ void PathfindZoneManager::calculateZones( PathfindCell **map, PathfindLayer laye
 
 
 
+	materializeZoneRoots(m_groundCliffZones, maxZone);
+	materializeZoneRoots(m_groundWaterZones, maxZone);
+	materializeZoneRoots(m_groundRubbleZones, maxZone);
+	materializeZoneRoots(m_terrainZones, maxZone);
+	materializeZoneRoots(m_crusherZones, maxZone);
+	materializeZoneRoots(m_hierarchicalZones, maxZone);
 
 //	if (m_maxZone >= m_zonesAllocated) {
 //		RELEASE_CRASH("Pathfind allocation error - fatal. see jba.");
@@ -3825,15 +3976,24 @@ void PathfindLayer::classifyWallMapCell( Int i, Int j , PathfindCell *cell, Obje
 
 //----------------------- Pathfinder ---------------------------------------
 
-Pathfinder::Pathfinder( void ) :m_map(NULL)
+Pathfinder::Pathfinder( void ) :
+	m_map(NULL),
+	m_fastOpenBucketHeads(NULL),
+	m_fastOpenBucketTails(NULL)
 {
 	debugPath = NULL;
 	PathfindCellInfo::allocateCellInfos();
+	m_fastOpenBucketHeads = new PathfindCell *[1 << 16]();
+	m_fastOpenBucketTails = new PathfindCell *[1 << 16]();
 	reset();
 }
 
 Pathfinder::~Pathfinder( void )
 {
+	delete [] m_fastOpenBucketHeads;
+	delete [] m_fastOpenBucketTails;
+	m_fastOpenBucketHeads = NULL;
+	m_fastOpenBucketTails = NULL;
 	PathfindCellInfo::releaseCellInfos();
 }
 
@@ -3841,6 +4001,8 @@ void Pathfinder::reset( void )
 {
 	frameToShowObstacles = 0;
 	DEBUG_LOG(("Pathfind cell is %d bytes, PathfindCellInfo is %d bytes\n", sizeof(PathfindCell), sizeof(PathfindCellInfo)));
+	memset(m_fastOpenBucketHeads, 0, (1 << 16) * sizeof(*m_fastOpenBucketHeads));
+	memset(m_fastOpenBucketTails, 0, (1 << 16) * sizeof(*m_fastOpenBucketTails));
 
 	if (m_blockOfMapCells) {
 		delete []m_blockOfMapCells;
@@ -3861,6 +4023,9 @@ void Pathfinder::reset( void )
 	m_logicalExtent.lo.x=m_logicalExtent.lo.y=m_logicalExtent.hi.x=m_logicalExtent.hi.y=0;
 	m_openList = NULL;
 	m_closedList = NULL;
+	m_fastOpenCount = 0;
+	m_fastOpenMinimumCost = 1 << 16;
+	m_fastOpenQueueActive = false;
 
 	m_ignoreObstacleID = INVALID_ID;
 	m_isTunneling = false;
@@ -3870,6 +4035,7 @@ void Pathfinder::reset( void )
 	// pathfind grid cells have not been classified yet
 	m_isMapReady = false;
 	m_cumulativeCellsAllocated = 0;
+	m_pathfindCacheGeneration = 0;
 
 	debugPathPos.x = 0.0f;
 	debugPathPos.y = 0.0f;
@@ -4806,12 +4972,101 @@ Bool Pathfinder::validMovementTerrain( PathfindLayerEnum layer, const Locomotor*
 	return true;
 }
 
+void Pathfinder::startFastOpenQueue(PathfindCell *startCell)
+{
+	// putOnSortedOpenList inserts after existing cells with the same cost. Each
+	// cost bucket is therefore FIFO so A* tie ordering remains byte-for-byte
+	// equivalent without repeatedly walking the full sorted list.
+	DEBUG_ASSERTCRASH(startCell && startCell->getOpen(), ("Invalid fast open queue start cell."));
+	DEBUG_ASSERTCRASH(m_fastOpenCount == 0, ("Fast open queue was not empty."));
+	UnsignedInt cost = startCell->m_info->m_totalCost;
+	DEBUG_ASSERTCRASH(m_fastOpenBucketHeads[cost] == NULL && m_fastOpenBucketTails[cost] == NULL,
+		("Fast open queue bucket was not empty."));
+	m_fastOpenBucketHeads[cost] = startCell;
+	m_fastOpenBucketTails[cost] = startCell;
+	startCell->m_info->m_openBucketCost = static_cast<UnsignedShort>(cost);
+	m_fastOpenCount = 1;
+	m_fastOpenMinimumCost = cost;
+	m_fastOpenQueueActive = true;
+	m_openList = NULL;
+}
+
+void Pathfinder::pushFastOpenQueue(PathfindCell *cell)
+{
+	DEBUG_ASSERTCRASH(cell->m_info && !cell->m_info->m_open && !cell->m_info->m_closed,
+		("Invalid cell added to fast open queue."));
+	UnsignedInt cost = cell->m_info->m_totalCost;
+	cell->m_info->m_openBucketCost = static_cast<UnsignedShort>(cost);
+	PathfindCell *tail = m_fastOpenBucketTails[cost];
+	cell->m_info->m_prevOpen = tail ? tail->m_info : NULL;
+	cell->m_info->m_nextOpen = NULL;
+	if (tail) {
+		tail->m_info->m_nextOpen = cell->m_info;
+	} else {
+		m_fastOpenBucketHeads[cost] = cell;
+	}
+	m_fastOpenBucketTails[cost] = cell;
+	cell->m_info->m_open = true;
+	cell->m_info->m_closed = false;
+	m_fastOpenCount++;
+	if (cost < m_fastOpenMinimumCost) {
+		m_fastOpenMinimumCost = cost;
+	}
+}
+
+void Pathfinder::removeFastOpenQueue(PathfindCell *cell)
+{
+	DEBUG_ASSERTCRASH(cell->m_info && cell->m_info->m_open && !cell->m_info->m_closed,
+		("Cell is not in the fast open queue."));
+	UnsignedInt cost = cell->m_info->m_openBucketCost;
+	PathfindCellInfo *prev = cell->m_info->m_prevOpen;
+	PathfindCellInfo *next = cell->m_info->m_nextOpen;
+	if (prev) {
+		prev->m_nextOpen = next;
+	} else {
+		DEBUG_ASSERTCRASH(m_fastOpenBucketHeads[cost] == cell, ("Invalid fast open queue head."));
+		m_fastOpenBucketHeads[cost] = next ? next->m_cell : NULL;
+	}
+	if (next) {
+		next->m_prevOpen = prev;
+	} else {
+		DEBUG_ASSERTCRASH(m_fastOpenBucketTails[cost] == cell, ("Invalid fast open queue tail."));
+		m_fastOpenBucketTails[cost] = prev ? prev->m_cell : NULL;
+	}
+	cell->m_info->m_prevOpen = NULL;
+	cell->m_info->m_nextOpen = NULL;
+	cell->m_info->m_open = false;
+	m_fastOpenCount--;
+}
+
+PathfindCell *Pathfinder::popFastOpenQueue(void)
+{
+	if (m_fastOpenCount == 0) {
+		return NULL;
+	}
+	while (m_fastOpenMinimumCost < (1U << 16)
+		&& m_fastOpenBucketHeads[m_fastOpenMinimumCost] == NULL) {
+		m_fastOpenMinimumCost++;
+	}
+	DEBUG_ASSERTCRASH(m_fastOpenMinimumCost < (1U << 16), ("Fast open queue has no minimum cell."));
+	PathfindCell *cell = m_fastOpenBucketHeads[m_fastOpenMinimumCost];
+	removeFastOpenQueue(cell);
+	return cell;
+}
+
 //
 // Releases the cells on the open & closed lists.
 //
 void Pathfinder::cleanOpenAndClosedLists(void) {
 	Int count = 0;
-	if (m_openList) {
+	if (m_fastOpenQueueActive) {
+		while (m_fastOpenCount != 0) {
+			PathfindCell *cell = popFastOpenQueue();
+			cell->releaseInfo();
+			count++;
+		}
+		m_openList = NULL;
+	} else if (m_openList) {
 		count += PathfindCell::releaseOpenList(m_openList);
 		m_openList = NULL;
 	}		 
@@ -4819,6 +5074,9 @@ void Pathfinder::cleanOpenAndClosedLists(void) {
 		count += PathfindCell::releaseClosedList(m_closedList);
 		m_closedList = NULL;
 	}		 
+	m_fastOpenCount = 0;
+	m_fastOpenMinimumCost = 1 << 16;
+	m_fastOpenQueueActive = false;
 	m_cumulativeCellsAllocated += count;
 //#ifdef _DEBUG
 #if 0
@@ -5997,8 +6255,11 @@ void Pathfinder::checkChangeLayers(PathfindCell *parentCell)
 					// store cost of this path
 					newCell->setCostSoFar(parentCell->getCostSoFar()); // same as parent cost
 					newCell->setTotalCost(parentCell->getTotalCost()) ;
-					// insert newCell in open list such that open list is sorted, smallest total path cost first
-					m_openList = newCell->putOnSortedOpenList( m_openList );
+					if (m_fastOpenQueueActive) {
+						pushFastOpenQueue(newCell);
+					} else {
+						m_openList = newCell->putOnSortedOpenList(m_openList);
+					}
 
 				}
 			}
@@ -6015,6 +6276,7 @@ struct ExamineCellsStruct
 	Int									radius;
 	const Object				*obj;
 	PathfindCell				*goalCell;
+	UnsignedInt				movementCacheGeneration;
 };
 
 /*static*/ Int Pathfinder::examineCellsCallback(Pathfinder* pathfinder, PathfindCell* from, PathfindCell* to, Int to_x, Int to_y, void* userData)
@@ -6023,10 +6285,49 @@ struct ExamineCellsStruct
 	Bool isCrusher = d->obj ? d->obj->getCrusherLevel() > 0 : false;
 	if (d->thePathfinder->m_isTunneling) return 1; // abort.
 	if (from && to) {
-			if (!d->thePathfinder->validMovementPosition( isCrusher, d->theLoco->getValidSurfaces(), to, from )) {
-				return 1;
+			Bool linePassable = false;
+			if (!to->getCachedLinePassability(d->movementCacheGeneration, linePassable)) {
+				linePassable = d->thePathfinder->validMovementPosition(
+					isCrusher, d->theLoco->getValidSurfaces(), to, from);
+				if (linePassable && to->getLayer() == LAYER_GROUND
+					&& !d->thePathfinder->m_zoneManager.isPassable(to_x, to_y)) {
+					linePassable = false;
+				}
+				if (linePassable && to->getPinched()) {
+					linePassable = false;
+				}
+				if (linePassable && d->isHuman
+					&& (to_x < d->thePathfinder->m_logicalExtent.lo.x
+						|| to_y < d->thePathfinder->m_logicalExtent.lo.y
+						|| to_x > d->thePathfinder->m_logicalExtent.hi.x
+						|| to_y > d->thePathfinder->m_logicalExtent.hi.y)) {
+					linePassable = false;
+				}
+				TCheckMovementInfo info;
+				if (linePassable) {
+					info.cell.x = to_x;
+					info.cell.y = to_y;
+					info.layer = from->getLayer();
+					info.centerInCell = d->centerInCell;
+					info.radius = d->radius;
+					info.considerTransient = false;
+					info.acceptableSurfaces = d->theLoco->getValidSurfaces();
+					Bool movementPassable = false;
+					if (to->getCachedMovementCheck(d->movementCacheGeneration, info.layer, movementPassable,
+						info.allyFixedCount, info.allyMoving, info.allyGoal, info.enemyFixed)) {
+					} else {
+						movementPassable = d->thePathfinder->checkForMovement(d->obj, info);
+						to->cacheMovementCheck(d->movementCacheGeneration, info.layer, movementPassable,
+							info.allyFixedCount, info.allyMoving, info.allyGoal, info.enemyFixed);
+					}
+					linePassable = movementPassable && !info.enemyFixed && !info.allyFixedCount;
+				}
+				if (linePassable && to->getType() == PathfindCell::CELL_CLIFF) {
+					linePassable = false;
+				}
+				to->cacheLinePassability(d->movementCacheGeneration, linePassable);
 			}
-			if ( (to->getLayer() == LAYER_GROUND) && !d->thePathfinder->m_zoneManager.isPassable(to_x, to_y) ) {
+			if (!linePassable) {
 				return 1;
 			}
 			Bool onList = false;
@@ -6037,48 +6338,15 @@ struct ExamineCellsStruct
 					onList = true;
 				}
 			}
-			if (to->getPinched()) {
-				return 1; // abort.
-			}
-			if (d->isHuman) {
-				// check if new cell is in logical map.	(computer can move off logical map)
-				if (to_x < d->thePathfinder->m_logicalExtent.lo.x) return 1; // abort
-				if (to_y < d->thePathfinder->m_logicalExtent.lo.y) return 1; // abort 
-				if (to_x > d->thePathfinder->m_logicalExtent.hi.x) return 1; // abort 
-				if (to_y > d->thePathfinder->m_logicalExtent.hi.y) return 1; // abort 
-			}
-			TCheckMovementInfo info;
-			info.cell.x = to_x;
-			info.cell.y = to_y;
-			info.layer = from->getLayer();
-			info.centerInCell = d->centerInCell;
-			info.radius = d->radius;
-			info.considerTransient = false;
-			info.acceptableSurfaces = d->theLoco->getValidSurfaces();
-			if (!d->thePathfinder->checkForMovement(d->obj, info) || info.enemyFixed) {
-				return 1; //abort.
-			}	
-			if (info.enemyFixed) {
-				return 1; //abort.
-			}
 			ICoord2D newCellCoord;
 			newCellCoord.x = to_x;
 			newCellCoord.y = to_y;
 
 			UnsignedInt newCostSoFar = from->getCostSoFar( ) + 0.5f*COST_ORTHOGONAL;
-			if (to->getType() == PathfindCell::CELL_CLIFF ) {
-				return 1;
-			}
-			if (info.allyFixedCount) {
-				return 1;
-			} else if (info.enemyFixed) {
-				return 1;
-			}
-
 			if (!to->allocateInfo(newCellCoord)) {
 				// Out of cells for pathing...
  				return 1;
-			}								
+			}
 			to->setBlockedByAlly(false);
 			Int costRemaining = 0;
 			costRemaining = to->costToGoal( d->goalCell );
@@ -6089,7 +6357,7 @@ struct ExamineCellsStruct
 				// already on one of the lists - if existing costSoFar is less, 
 				// the new cell is on a longer path, so skip it
 				if (to->getCostSoFar() <= newCostSoFar)
-					return 0; // keep going.
+					return 0;	// keep going
 			}
 			to->setCostSoFar(newCostSoFar);
 			// keep track of path we're building - point back to cell we moved here from
@@ -6105,14 +6373,109 @@ struct ExamineCellsStruct
 				d->thePathfinder->m_closedList = to->removeFromClosedList( d->thePathfinder->m_closedList );
 
 			// if the to was already on the open list, remove it so it can be re-inserted in order
-			if (to->getOpen())
-				d->thePathfinder->m_openList = to->removeFromOpenList( d->thePathfinder->m_openList );
+			if (to->getOpen()) {
+				if (d->thePathfinder->m_fastOpenQueueActive) {
+					d->thePathfinder->removeFastOpenQueue(to);
+				} else {
+					d->thePathfinder->m_openList = to->removeFromOpenList(d->thePathfinder->m_openList);
+				}
+			}
 
-			// insert to in open list such that open list is sorted, smallest total path cost first
-			d->thePathfinder->m_openList = to->putOnSortedOpenList( d->thePathfinder->m_openList );
+			if (d->thePathfinder->m_fastOpenQueueActive) {
+				d->thePathfinder->pushFastOpenQueue(to);
+			} else {
+				d->thePathfinder->m_openList = to->putOnSortedOpenList(d->thePathfinder->m_openList);
+			}
 	}
 
 	return 0;	// keep going
+}
+
+Int Pathfinder::examineLineCell(PathfindCell *from, PathfindCell *to, Int toX, Int toY, void *userData)
+{
+	ExamineCellsStruct *info = static_cast<ExamineCellsStruct *>(userData);
+	if (from && to) {
+		Bool linePassable = false;
+		if (to->getCachedLinePassability(info->movementCacheGeneration, linePassable)) {
+			if (!linePassable) {
+				return 1;
+			}
+			if (to->hasInfo() && !to->isBlockedByAlly()
+				&& (to->getOpen() || to->getClosed())
+				&& to->getCostSoFar() <= from->getCostSoFar() + COST_ORTHOGONAL / 2) {
+				return 0;
+			}
+		}
+	}
+	return examineCellsCallback(this, from, to, toX, toY, userData);
+}
+
+Int Pathfinder::examineCellsAlongLine(const ICoord2D &start, const ICoord2D &end,
+	PathfindLayerEnum layer, void *userData)
+{
+	Int deltaX = abs(end.x - start.x);
+	Int deltaY = abs(end.y - start.y);
+	Int x = start.x;
+	Int y = start.y;
+	Int xinc1 = end.x >= start.x ? 1 : -1;
+	Int xinc2 = xinc1;
+	Int yinc1 = end.y >= start.y ? 1 : -1;
+	Int yinc2 = yinc1;
+	Int denominator;
+	Int numerator;
+	Int numeratorAdd;
+	Int pixelCount;
+	if (deltaX >= deltaY) {
+		xinc1 = 0;
+		yinc2 = 0;
+		denominator = deltaX;
+		numerator = deltaX / 2;
+		numeratorAdd = deltaY;
+		pixelCount = deltaX;
+	} else {
+		xinc2 = 0;
+		yinc1 = 0;
+		denominator = deltaY;
+		numerator = deltaY / 2;
+		numeratorAdd = deltaX;
+		pixelCount = deltaY;
+	}
+
+	PathfindCell *from = NULL;
+	const Bool groundLayer = layer == LAYER_GROUND;
+	for (Int pixel = 0; pixel <= pixelCount; pixel++) {
+		// Both endpoints are map cells, so every Bresenham step between them is
+		// in bounds. Ground paths can avoid repeating getCell's bounds and layer
+		// checks for every cell along every candidate ray.
+		PathfindCell *to = groundLayer ? &m_map[x][y] : getCell(layer, x, y);
+		if (to == NULL) {
+			return 0;
+		}
+		Int result = examineLineCell(from, to, x, y, userData);
+		if (result != 0) {
+			return result;
+		}
+
+		numerator += numeratorAdd;
+		if (numerator >= denominator) {
+			numerator -= denominator;
+			x += xinc1;
+			y += yinc1;
+			from = to;
+			to = groundLayer ? &m_map[x][y] : getCell(layer, x, y);
+			if (to == NULL) {
+				return 0;
+			}
+			result = examineLineCell(from, to, x, y, userData);
+			if (result != 0) {
+				return result;
+			}
+		}
+		x += xinc2;
+		y += yinc2;
+		from = to;
+	}
+	return 0;
 }
 
 
@@ -6120,7 +6483,8 @@ struct ExamineCellsStruct
 
 Int Pathfinder::examineNeighboringCells(PathfindCell *parentCell, PathfindCell *goalCell, const LocomotorSet& locomotorSet, 
 																				 Bool isHuman, Bool centerInCell, Int radius, const ICoord2D &startCellNdx,
-																				 const Object *obj, Int attackDistance)
+																				 const Object *obj, Int attackDistance,
+																				 UnsignedInt movementCacheGeneration)
 {
 		Bool canPathThroughUnits = false;
 		if (obj && obj->getAIUpdateInterface()) {
@@ -6136,12 +6500,17 @@ Int Pathfinder::examineNeighboringCells(PathfindCell *parentCell, PathfindCell *
 			info.obj = obj;
 			info.isHuman = isHuman;
 			info.goalCell = goalCell;
+			info.movementCacheGeneration = movementCacheGeneration;
 			ICoord2D start, end;
 			start.x = parentCell->getXIndex();
 			start.y = parentCell->getYIndex();
 			end.x = goalCell->getXIndex();
 			end.y = goalCell->getYIndex();
-			iterateCellsAlongLine(start, end, parentCell->getLayer(), examineCellsCallback, &info);
+			if (movementCacheGeneration != 0) {
+				examineCellsAlongLine(start, end, parentCell->getLayer(), &info);
+			} else {
+				iterateCellsAlongLine(start, end, parentCell->getLayer(), examineCellsCallback, &info);
+			}
 		}
 
 		Int cellCount = 0;
@@ -6230,7 +6599,7 @@ Int Pathfinder::examineNeighboringCells(PathfindCell *parentCell, PathfindCell *
 
 			Bool movementValid = true;
 			Bool dozerHack = false;
-			if (validMovementPosition( isCrusher, locomotorSet.getValidSurfaces(), newCell, parentCell )) {
+			if (validMovementPosition(isCrusher, locomotorSet.getValidSurfaces(), newCell, parentCell)) {
 			}	else {
 				movementValid = false;
 				if (obj->isKindOf(KINDOF_DOZER)) {
@@ -6262,7 +6631,15 @@ Int Pathfinder::examineNeighboringCells(PathfindCell *parentCell, PathfindCell *
 			if (dy<0) dy = -dy;
 			if (dx>1+radius) info.considerTransient = false;
 			if (dy>1+radius) info.considerTransient = false;
-			if (!checkForMovement(obj, info) || info.enemyFixed) {
+			Bool movementPassable = false;
+			if (newCell->getCachedMovementCheck(movementCacheGeneration, info.layer, movementPassable,
+				info.allyFixedCount, info.allyMoving, info.allyGoal, info.enemyFixed)) {
+			} else {
+				movementPassable = checkForMovement(obj, info);
+				newCell->cacheMovementCheck(movementCacheGeneration, info.layer, movementPassable,
+					info.allyFixedCount, info.allyMoving, info.allyGoal, info.enemyFixed);
+			}
+			if (!movementPassable || info.enemyFixed) {
 				if (!m_isTunneling) {
 					continue;
 				}
@@ -6371,11 +6748,19 @@ Int Pathfinder::examineNeighboringCells(PathfindCell *parentCell, PathfindCell *
 				m_closedList = newCell->removeFromClosedList( m_closedList );
 
 			// if the newCell was already on the open list, remove it so it can be re-inserted in order
-			if (newCell->getOpen())
-				m_openList = newCell->removeFromOpenList( m_openList );
+			if (newCell->getOpen()) {
+				if (m_fastOpenQueueActive) {
+					removeFastOpenQueue(newCell);
+				} else {
+					m_openList = newCell->removeFromOpenList(m_openList);
+				}
+			}
 
-			// insert newCell in open list such that open list is sorted, smallest total path cost first
-			m_openList = newCell->putOnSortedOpenList( m_openList );
+			if (m_fastOpenQueueActive) {
+				pushFastOpenQueue(newCell);
+			} else {
+				m_openList = newCell->putOnSortedOpenList(m_openList);
+			}
 		}
 	return cellCount;
 }
@@ -6600,21 +6985,25 @@ Path *Pathfinder::internalFindPath( Object *obj, const LocomotorSet& locomotorSe
 
 	// initialize "open" list to contain start cell
 	m_openList = parentCell;
+	startFastOpenQueue(parentCell);
 
 	// "closed" list is initially empty
 	m_closedList = NULL;
 
 	Int cellCount = 0;
+	if (++m_pathfindCacheGeneration == 0) {
+		++m_pathfindCacheGeneration;
+	}
+	const UnsignedInt movementCacheGeneration = m_pathfindCacheGeneration;
 
 	//
 	// Continue search until "open" list is empty, or
 	// until goal is found.
 	//
-	while( m_openList != NULL )
+	while (m_fastOpenCount != 0)
 	{
 		// take head cell off of open list - it has lowest estimated total path cost
-		parentCell = m_openList;
-		m_openList = parentCell->removeFromOpenList(m_openList);
+		parentCell = popFastOpenQueue();
 
 		if (parentCell == goalCell)
 		{
@@ -6652,7 +7041,8 @@ Path *Pathfinder::internalFindPath( Object *obj, const LocomotorSet& locomotorSe
 		// Check to see if we can change layers in this cell.
 		checkChangeLayers(parentCell);
 
-		cellCount += examineNeighboringCells(parentCell, goalCell, locomotorSet, isHuman, centerInCell, radius, startCellNdx, obj, NO_ATTACK);
+		cellCount += examineNeighboringCells(parentCell, goalCell, locomotorSet, isHuman, centerInCell, radius,
+			startCellNdx, obj, NO_ATTACK, movementCacheGeneration);
 
 	}
 
@@ -6781,6 +7171,21 @@ Int Pathfinder::clearCellForDiameter(Bool crusher, Int cellX, Int cellY, Pathfin
 	}
 	if (pathDiameter < 2) return 0;
 	return clearCellForDiameter(crusher, cellX, cellY, layer, pathDiameter-2);
+}
+
+Int Pathfinder::cachedClearCellForDiameter(UnsignedInt generation, Bool crusher, Int cellX, Int cellY,
+	PathfindLayerEnum layer, Int pathDiameter)
+{
+	PathfindCell *cell = getCell(layer, cellX, cellY);
+	Int clearDiameter = 0;
+	if (cell && cell->getCachedClearDiameter(generation, clearDiameter)) {
+		return clearDiameter;
+	}
+	clearDiameter = clearCellForDiameter(crusher, cellX, cellY, layer, pathDiameter);
+	if (cell) {
+		cell->cacheClearDiameter(generation, clearDiameter);
+	}
+	return clearDiameter;
 }
 
 /**
@@ -6954,6 +7359,7 @@ struct GroundCellsStruct
 	Int									pathDiameter;
 	PathfindCell				*goalCell;
 	Bool								crusher;
+	UnsignedInt				clearDiameterCacheGeneration;
 };
 
 /*static*/ Int Pathfinder::groundCellsCallback(Pathfinder* pathfinder, PathfindCell* from, PathfindCell* to, Int to_x, Int to_y, void* userData)
@@ -6968,7 +7374,8 @@ struct GroundCellsStruct
 				}
 			}
 			// See how wide the cell is.
-			Int clearDiameter = d->thePathfinder->clearCellForDiameter(d->crusher, to_x, to_y, to->getLayer(), d->pathDiameter); 
+			Int clearDiameter = d->thePathfinder->cachedClearCellForDiameter(
+				d->clearDiameterCacheGeneration, d->crusher, to_x, to_y, to->getLayer(), d->pathDiameter);
 			if (clearDiameter != d->pathDiameter) {
 				return 1;
 			}
@@ -6990,8 +7397,7 @@ struct GroundCellsStruct
 			to->setParentCell(from) ;
 			to->setTotalCost(to->getCostSoFar() + costRemaining) ;
 
-			// insert to in open list such that open list is sorted, smallest total path cost first
-			d->thePathfinder->m_openList = to->putOnSortedOpenList( d->thePathfinder->m_openList );
+			d->thePathfinder->pushFastOpenQueue(to);
 	}
 
 	return 0;	// keep going
@@ -7012,6 +7418,10 @@ Path *Pathfinder::findGroundPath( const Coord3D *from,
 	DEBUG_LOG(("Find ground path..."));
 #endif	
 	Bool centerInCell = false;
+	if (++m_pathfindCacheGeneration == 0) {
+		++m_pathfindCacheGeneration;
+	}
+	const UnsignedInt clearDiameterCacheGeneration = m_pathfindCacheGeneration;
 	
 	m_zoneManager.clearPassableFlags();
 	Bool isHuman = true;
@@ -7044,28 +7454,37 @@ Path *Pathfinder::findGroundPath( const Coord3D *from,
 	ICoord2D cell;
 	worldToCell( to, &cell );
 
-	if (pathDiameter!=clearCellForDiameter(crusher, cell.x, cell.y, destinationLayer, pathDiameter)) {
+	if (pathDiameter != cachedClearCellForDiameter(clearDiameterCacheGeneration,
+		crusher, cell.x, cell.y, destinationLayer, pathDiameter)) {
 		Int offset=1;
 		ICoord2D newCell;
 		const Int MAX_OFFSET = 8;
 		while (offset<MAX_OFFSET) {
 			newCell = cell;
 			cell.x += offset;
-			if (clearCellForDiameter(crusher, cell.x, cell.y, destinationLayer, pathDiameter)==pathDiameter) break;
+			if (cachedClearCellForDiameter(clearDiameterCacheGeneration, crusher,
+				cell.x, cell.y, destinationLayer, pathDiameter) == pathDiameter) break;
 			cell.y += offset;
-			if (clearCellForDiameter(crusher, cell.x, cell.y, destinationLayer, pathDiameter)==pathDiameter) break;
+			if (cachedClearCellForDiameter(clearDiameterCacheGeneration, crusher,
+				cell.x, cell.y, destinationLayer, pathDiameter) == pathDiameter) break;
 			cell.x -= offset;
-			if (clearCellForDiameter(crusher, cell.x, cell.y, destinationLayer, pathDiameter)==pathDiameter) break;
+			if (cachedClearCellForDiameter(clearDiameterCacheGeneration, crusher,
+				cell.x, cell.y, destinationLayer, pathDiameter) == pathDiameter) break;
 			cell.x -= offset;
-			if (clearCellForDiameter(crusher, cell.x, cell.y, destinationLayer, pathDiameter)==pathDiameter) break;
+			if (cachedClearCellForDiameter(clearDiameterCacheGeneration, crusher,
+				cell.x, cell.y, destinationLayer, pathDiameter) == pathDiameter) break;
 			cell.y -= offset;
-			if (clearCellForDiameter(crusher, cell.x, cell.y, destinationLayer, pathDiameter)==pathDiameter) break;
+			if (cachedClearCellForDiameter(clearDiameterCacheGeneration, crusher,
+				cell.x, cell.y, destinationLayer, pathDiameter) == pathDiameter) break;
 			cell.y -= offset;
-			if (clearCellForDiameter(crusher, cell.x, cell.y, destinationLayer, pathDiameter)==pathDiameter) break;
+			if (cachedClearCellForDiameter(clearDiameterCacheGeneration, crusher,
+				cell.x, cell.y, destinationLayer, pathDiameter) == pathDiameter) break;
 			cell.x += offset;
-			if (clearCellForDiameter(crusher, cell.x, cell.y, destinationLayer, pathDiameter)==pathDiameter) break;
+			if (cachedClearCellForDiameter(clearDiameterCacheGeneration, crusher,
+				cell.x, cell.y, destinationLayer, pathDiameter) == pathDiameter) break;
 			cell.x += offset;
-			if (clearCellForDiameter(crusher, cell.x, cell.y, destinationLayer, pathDiameter)==pathDiameter) break;
+			if (cachedClearCellForDiameter(clearDiameterCacheGeneration, crusher,
+				cell.x, cell.y, destinationLayer, pathDiameter) == pathDiameter) break;
 			offset++;
 			cell = newCell;
 		}
@@ -7115,6 +7534,7 @@ Path *Pathfinder::findGroundPath( const Coord3D *from,
 
 	// initialize "open" list to contain start cell
 	m_openList = parentCell;
+	startFastOpenQueue(parentCell);
 
 	// "closed" list is initially empty
 	m_closedList = NULL;
@@ -7124,11 +7544,10 @@ Path *Pathfinder::findGroundPath( const Coord3D *from,
 	// until goal is found.
 	//
 	Int cellCount = 0;
-	while( m_openList != NULL )
+	while (m_fastOpenCount != 0)
 	{
 		// take head cell off of open list - it has lowest estimated total path cost
-		parentCell = m_openList;
-		m_openList = parentCell->removeFromOpenList(m_openList);
+		parentCell = popFastOpenQueue();
 
 		if (parentCell == goalCell)
 		{
@@ -7162,6 +7581,7 @@ Path *Pathfinder::findGroundPath( const Coord3D *from,
 		info.pathDiameter = pathDiameter;
 		info.goalCell = goalCell;
 		info.crusher = crusher;
+		info.clearDiameterCacheGeneration = clearDiameterCacheGeneration;
 		ICoord2D start, end;
 		start.x = parentCell->getXIndex();
 		start.y = parentCell->getYIndex();
@@ -7227,9 +7647,9 @@ Path *Pathfinder::findGroundPath( const Coord3D *from,
 						continue;
 					}
 				}
-
 				// See how wide the cell is.
-				clearDiameter = clearCellForDiameter(crusher, newCellCoord.x, newCellCoord.y, newCell->getLayer(), pathDiameter); 
+				clearDiameter = cachedClearCellForDiameter(clearDiameterCacheGeneration, crusher,
+					newCellCoord.x, newCellCoord.y, newCell->getLayer(), pathDiameter);
 				if (newCell->getType() != PathfindCell::CELL_CLEAR) {
 					continue;
 				}
@@ -7280,11 +7700,11 @@ Path *Pathfinder::findGroundPath( const Coord3D *from,
 				m_closedList = newCell->removeFromClosedList( m_closedList );
 
 			// if the newCell was already on the open list, remove it so it can be re-inserted in order
-			if (newCell->getOpen())
-				m_openList = newCell->removeFromOpenList( m_openList );
+			if (newCell->getOpen()) {
+				removeFastOpenQueue(newCell);
+			}
 
-			// insert newCell in open list such that open list is sorted, smallest total path cost first
-			m_openList = newCell->putOnSortedOpenList( m_openList );
+			pushFastOpenQueue(newCell);
 		}
 
 
@@ -8792,9 +9212,14 @@ Path *Pathfinder::findClosestPath( Object *obj, const LocomotorSet& locomotorSet
 	PathfindCell *closesetCell = NULL;
 	Real closestDistanceSqr = FLT_MAX;
 	Real closestDistScreenSqr = FLT_MAX;
+	if (++m_pathfindCacheGeneration == 0) {
+		++m_pathfindCacheGeneration;
+	}
+	const UnsignedInt movementCacheGeneration = m_pathfindCacheGeneration;
 
 	// initialize "open" list to contain start cell
 	m_openList = parentCell;
+	startFastOpenQueue(parentCell);
 
 	// "closed" list is initially empty
 	m_closedList = NULL;
@@ -8804,14 +9229,13 @@ Path *Pathfinder::findClosestPath( Object *obj, const LocomotorSet& locomotorSet
 	// until goal is found.
 	//
 	Bool foundGoal = false;
-	while( m_openList != NULL )
+	while( m_fastOpenCount != 0 )
 	{
 		Real dx;
 		Real dy;
 		Real distSqr;
 		// take head cell off of open list - it has lowest estimated total path cost
-		parentCell = m_openList;
-		m_openList = parentCell->removeFromOpenList(m_openList);
+		parentCell = popFastOpenQueue();
 
 		if (parentCell == goalCell)
 		{
@@ -8895,7 +9319,8 @@ Path *Pathfinder::findClosestPath( Object *obj, const LocomotorSet& locomotorSet
 		if (!foundGoal) {
 			// Check to see if we can change layers in this cell.
 			checkChangeLayers(parentCell);
-			count += examineNeighboringCells(parentCell, goalCell, locomotorSet, isHuman, centerInCell, radius, startCellNdx, obj, NO_ATTACK);
+			count += examineNeighboringCells(parentCell, goalCell, locomotorSet, isHuman,
+				centerInCell, radius, startCellNdx, obj, NO_ATTACK, movementCacheGeneration);
 		}
 	}
 
@@ -9621,13 +10046,15 @@ struct GroundPathPassableStruct
 {
 	Int		diameter;
 	Bool	crusher;
+	UnsignedInt clearDiameterCacheGeneration;
 };
 
 /*static*/ Int Pathfinder::groundPathPassableCallback(Pathfinder* pathfinder, PathfindCell* from, PathfindCell* to, Int to_x, Int to_y, void* userData)
 {
 	const GroundPathPassableStruct* d = (const GroundPathPassableStruct*)userData;
 
-	Int curDiameter = pathfinder->clearCellForDiameter(d->crusher, to_x, to_y, to->getLayer(), d->diameter);
+	Int curDiameter = pathfinder->cachedClearCellForDiameter(d->clearDiameterCacheGeneration,
+		d->crusher, to_x, to_y, to->getLayer(), d->diameter);
 	if (curDiameter==d->diameter) return 0;	//  good to go.
 	if (from && to->getLayer() != LAYER_GROUND && from->getLayer() == to->getLayer()) {
 		return 0;
@@ -9673,6 +10100,7 @@ Bool Pathfinder::isGroundPathPassable( Bool isCrusher, const Coord3D& startWorld
 
 	info.diameter = pathDiameter;
 	info.crusher = isCrusher;
+	info.clearDiameterCacheGeneration = m_fastOpenQueueActive ? m_pathfindCacheGeneration : 0;
 
 	Int ret = iterateCellsAlongLine(startWorld, endWorld, startLayer, groundPathPassableCallback, (void*)&info);
 	return ret == 0;

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -1751,6 +1751,14 @@ void W3DDisplay::draw( void )
 	CNC_PORT_NOTE_W3D_DISPLAY_STEP("W3DDisplay.draw.fpsBefore");
 	updateAverageFPS();
 	CNC_PORT_NOTE_W3D_DISPLAY_STEP("W3DDisplay.draw.fpsAfter");
+	// The disable-render switch is also used to isolate simulation work in
+	// deterministic replay profiling. Avoid all view, shroud, particle, and
+	// render-target updates while it is set; the old Begin_Render-only check
+	// still performed most of the GPU work before suppressing presentation.
+	if (TheGlobalData->m_disableRender)
+	{
+		return;
+	}
 	if (TheGlobalData->m_enableDynamicLOD && TheGameLogic->getShowDynamicLOD())
 	{
 		DynamicGameLODLevel lod=TheGameLODManager->findDynamicLODLevel(m_averageFPS);

--- a/WebAssembly/harness/bridge.js
+++ b/WebAssembly/harness/bridge.js
@@ -1965,6 +1965,17 @@ async function threadedRpc(command, payload = {}) {
         return { ok: false, command, error: error?.message ?? String(error), threaded: true };
       }
     }
+    case "realEngineSetRenderDisabled": {
+      try {
+        const disabled = payload.disabled === true;
+        const applied = await threadedEngine.engineCall(
+          "cnc_port_real_engine_set_render_disabled", "number", ["number"],
+          [disabled ? 1 : 0]);
+        return { ok: applied === 1, command, disabled, threaded: true };
+      } catch (error) {
+        return { ok: false, command, error: error?.message ?? String(error), threaded: true };
+      }
+    }
     case "querySelection": {
       try {
         const result = await threadedEngine.engineCall(
@@ -6396,6 +6407,11 @@ async function loadWasmModule() {
       realEngineSetPlayerDiagnostics: module.cwrap(
         "cnc_port_real_engine_set_player_diagnostics",
         null,
+        ["number"],
+      ),
+      realEngineSetRenderDisabled: module.cwrap(
+        "cnc_port_real_engine_set_render_disabled",
+        "number",
         ["number"],
       ),
       realEngineDoFX: module.cwrap(
@@ -12523,7 +12539,11 @@ async function rpc(command, payload = {}) {
     case "importReplay":
       {
         try {
-          const result = await replayFileStore.importFile(payload.name, base64ToBytes(payload.bytesBase64));
+          const result = await replayFileStore.importFile(
+            payload.name,
+            base64ToBytes(payload.bytesBase64),
+            { durable: payload.persist !== false },
+          );
           return { command, ...result };
         } catch (error) {
           return { ok: false, command, error: error?.message ?? String(error) };
@@ -13499,6 +13519,16 @@ async function rpc(command, payload = {}) {
           result,
           state: snapshotState(),
         };
+      }
+    case "realEngineSetRenderDisabled":
+      {
+        const moduleResult = await getWasmModuleForArchives("realEngineSetRenderDisabled");
+        if (moduleResult.error) {
+          return { ok: false, command, error: moduleResult.error };
+        }
+        const disabled = payload.disabled === true;
+        const applied = moduleResult.wasmModule.realEngineSetRenderDisabled(disabled ? 1 : 0);
+        return { ok: applied === 1, command, disabled, state: snapshotState() };
       }
     case "revealLocalMap":
       {

--- a/WebAssembly/harness/engine_realm_boot.mjs
+++ b/WebAssembly/harness/engine_realm_boot.mjs
@@ -742,10 +742,15 @@ export default async function setupEngineRealm({ canvas, Module, realm, options 
     nextLogicDue: null,
     clientFrames: 0, // cumulative paced client frames run
     logicFrames: 0, // cumulative logic frames run
+    engineFrameSamples: 0, // cumulative timed engine frames run
+    replayPlaybackSeen: false,
+    crcMismatch: false,
     startedAt: null,
     lastResult: null,
     lastClientFrameStamp: null,
     engineFrameTimes: [], // rolling real-engine update durations (ms)
+    engineLogicFrames: [], // logic frame aligned with each engineFrameTimes sample
+    slowFrameProfiles: [], // slowest profiled frames since the loop started
     presentationFrameTimes: [], // rolling intervals between presented client frames (ms)
     pacingSamples: [], // last ~900 {t, logic} for pacing-evenness probes
     quitRequested: false,
@@ -791,13 +796,50 @@ export default async function setupEngineRealm({ canvas, Module, realm, options 
     loop.nextLogicDue = null;
     loop.clientFrames = 0;
     loop.logicFrames = 0;
+    loop.engineFrameSamples = 0;
+    loop.replayPlaybackSeen = false;
+    loop.crcMismatch = false;
     loop.startedAt = performance.now();
     loop.lastClientFrameStamp = null;
     loop.engineFrameTimes.length = 0;
+    loop.engineLogicFrames.length = 0;
+    loop.slowFrameProfiles.length = 0;
     loop.presentationFrameTimes.length = 0;
     loop.pacingSamples.length = 0;
     loop.quitRequested = false;
     respond({ cmd: "startLoopResult", id: msg.id, ok: true, pacing, clientFps, logicFps });
+  }
+
+  function recordEngineFrame(result) {
+    const engineFrameMs = Number(result?.lastFrameMs);
+    if (!Number.isFinite(engineFrameMs) || engineFrameMs < 0) {
+      return;
+    }
+    loop.engineFrameSamples += 1;
+    const engineFrameSample = loop.engineFrameSamples;
+    loop.engineFrameTimes.push(engineFrameMs);
+    loop.engineLogicFrames.push(Number(result?.logicFrame));
+    if (result?.recorder?.playback === true) {
+      loop.replayPlaybackSeen = true;
+    }
+    if (result?.recorder?.crcMismatch === true) {
+      loop.crcMismatch = true;
+    }
+    if (loop.engineFrameTimes.length > 600) {
+      loop.engineFrameTimes.shift();
+      loop.engineLogicFrames.shift();
+    }
+    loop.slowFrameProfiles.push({
+      engineFrameSample,
+      logicFrame: result.logicFrame ?? null,
+      clientFrame: result.clientFrame ?? null,
+      lastFrameMs: engineFrameMs,
+      profile: result?.profile ?? null,
+    });
+    loop.slowFrameProfiles.sort((a, b) => b.lastFrameMs - a.lastFrameMs);
+    if (loop.slowFrameProfiles.length > 50) {
+      loop.slowFrameProfiles.length = 50;
+    }
   }
 
   function pumpLoop(stamp) {
@@ -841,9 +883,11 @@ export default async function setupEngineRealm({ canvas, Module, realm, options 
     try {
       if (logicToRun === 0) {
         result = runPacedFrame(false);
+        recordEngineFrame(result);
       } else {
         for (let i = 0; i < logicToRun; i += 1) {
           result = runPacedFrame(true);
+          recordEngineFrame(result);
           loop.logicFrames += 1;
           if (result?.quitting === true) {
             break;
@@ -871,13 +915,6 @@ export default async function setupEngineRealm({ canvas, Module, realm, options 
       }
     }
     loop.lastClientFrameStamp = stamp;
-    const engineFrameMs = Number(result.lastFrameMs);
-    if (Number.isFinite(engineFrameMs) && engineFrameMs >= 0) {
-      loop.engineFrameTimes.push(engineFrameMs);
-      if (loop.engineFrameTimes.length > 600) {
-        loop.engineFrameTimes.shift();
-      }
-    }
     loop.clientFrames += 1;
     loop.lastResult = result;
     const browserCursor = result.browserCursor;
@@ -949,11 +986,16 @@ export default async function setupEngineRealm({ canvas, Module, realm, options 
         startedAt: loop.startedAt,
         clientFrames: loop.clientFrames,
         logicFrames: loop.logicFrames,
+        engineFrameSamples: loop.engineFrameSamples,
+        replayPlaybackSeen: loop.replayPlaybackSeen,
+        crcMismatch: loop.crcMismatch,
         quitRequested: loop.quitRequested,
       },
       timing: {
         engineFrameMs: loop.engineFrameTimes.slice(),
+        engineLogicFrames: loop.engineLogicFrames.slice(),
         presentationFrameMs: loop.presentationFrameTimes.slice(),
+        slowFrameProfiles: loop.slowFrameProfiles.slice(),
       },
       frame: result ? {
         logicFrame: result.logicFrame,
@@ -963,6 +1005,7 @@ export default async function setupEngineRealm({ canvas, Module, realm, options 
         loadProgress: result.loadProgress,
         lastFrameMs: result.lastFrameMs,
         quitting: result.quitting,
+        recorder: result.recorder ?? null,
       } : null,
       networkDiagnostics,
       touchUi,

--- a/WebAssembly/harness/replay-file-store.mjs
+++ b/WebAssembly/harness/replay-file-store.mjs
@@ -119,13 +119,16 @@ export function createReplayFileStore({
     return new Uint8Array(bytes);
   }
 
-  async function importFile(name, value) {
+  async function importFile(name, value, { durable = true } = {}) {
     const requested = replayName(name);
     const bytes = replayBytes(value);
     const FS = await filesystem();
     const finalName = uniqueReplayName(FS, requested, directory);
     const path = `${directory}/${finalName}`;
     FS.writeFile(path, bytes, { canOwn: false });
+    if (!durable) {
+      return { ok: true, name: finalName, size: bytes.byteLength, persisted: false };
+    }
     const result = await persist("replay-import");
     if (!result?.ok) {
       try { FS.unlink(path); } catch { /* best-effort rollback */ }

--- a/WebAssembly/harness/replay_file_store_unit.mjs
+++ b/WebAssembly/harness/replay_file_store_unit.mjs
@@ -50,7 +50,11 @@ const first = await store.importFile("battle.rep", retailShape);
 assert.deepEqual(first, { ok: true, name: "battle.rep", size: 10, persisted: true });
 const second = await store.importFile("battle.rep", retailShape.buffer);
 assert.equal(second.name, "battle (2).rep");
-assert.deepEqual((await store.list()).files.map((file) => file.name), ["battle (2).rep", "battle.rep"]);
+const volatile = await store.importFile("profile-only.rep", retailShape, { durable: false });
+assert.deepEqual(volatile,
+  { ok: true, name: "profile-only.rep", size: 10, persisted: false });
+assert.deepEqual((await store.list()).files.map((file) => file.name),
+  ["battle (2).rep", "battle.rep", "profile-only.rep"]);
 assert.deepEqual(await store.read("battle.rep"), retailShape);
 assert.deepEqual(persistReasons, ["replay-import", "replay-import"]);
 
@@ -62,7 +66,8 @@ await assert.rejects(() => store.importFile("huge.rep", new Uint8Array(MAX_REPLA
 fake.FS.writeFile(`${replayDirectory}/00000000.rep`, retailShape);
 await assert.rejects(() => store.remove("00000000.rep"), /protected/);
 await store.remove("battle.rep");
-assert.deepEqual((await store.list()).files.map((file) => file.name), ["00000000.rep", "battle (2).rep"]);
+assert.deepEqual((await store.list()).files.map((file) => file.name),
+  ["00000000.rep", "battle (2).rep", "profile-only.rep"]);
 assert.equal(persistReasons.at(-1), "replay-delete");
 
 console.log("replay file store unit: PASS");

--- a/WebAssembly/harness/skirmish_start_smoke.mjs
+++ b/WebAssembly/harness/skirmish_start_smoke.mjs
@@ -16,6 +16,7 @@ const D3DTOP_DISABLE = 1;
 const WM_MOUSEMOVE = 0x0200;
 const WM_LBUTTONDOWN = 0x0201;
 const WM_LBUTTONUP = 0x0202;
+const omitAudioArchives = process.env.SKIRMISH_START_OMIT_AUDIO_ARCHIVES === "1";
 
 const archiveSpecs = [
   { name: "INIZH.big" },
@@ -48,7 +49,9 @@ const archiveSpecs = [
   { name: "ZZBase_SpeechEnglish.big", sourceName: "base-generals/SpeechEnglish.big" },
   { name: "ZZBase_Maps.big", sourceName: "base-generals/Maps.big" },
   { name: "Gensec.big" },
-];
+].filter((spec) => !omitAudioArchives
+  || !/^(?:(?:AudioEnglish|SpeechEnglish)ZH|base-generals\/(?:Audio(?:English)?|Speech(?:English)?))\.big$/i
+    .test(spec.sourceName ?? spec.name));
 
 const screenshotPath = resolve(
   process.env.SKIRMISH_START_SCREENSHOT ??
@@ -84,6 +87,21 @@ const captureD3D8History = process.env.SKIRMISH_START_CAPTURE_D3D8_HISTORY === "
 const expectLightPulseProbe = process.env.SKIRMISH_START_LIGHT_PULSE_PROBE === "1";
 const expectReplayRoundTrip = process.env.SKIRMISH_START_REPLAY_ROUNDTRIP === "1";
 const retailReplayFixture = String(process.env.SKIRMISH_REPLAY_FIXTURE ?? "").trim();
+const expectReplayPerformance = process.env.SKIRMISH_START_REPLAY_PERFORMANCE === "1";
+const requireReplayPerformanceVisible =
+  process.env.SKIRMISH_REPLAY_PERFORMANCE_REQUIRE_VISIBLE !== "0";
+const disableReplayPerformanceRender =
+  process.env.SKIRMISH_REPLAY_PERFORMANCE_DISABLE_RENDER === "1";
+const profileReplayPerformance =
+  process.env.SKIRMISH_REPLAY_PERFORMANCE_PROFILE !== "0";
+const replayPerformanceClientFps = parsePositiveInt(
+  "SKIRMISH_REPLAY_PERFORMANCE_CLIENT_FPS", 60);
+const replayPerformanceLogicFps = parsePositiveInt(
+  "SKIRMISH_REPLAY_PERFORMANCE_LOGIC_FPS", 30);
+const replayPerformanceCatchup = parsePositiveInt(
+  "SKIRMISH_REPLAY_PERFORMANCE_CATCHUP", 2);
+const replayPerformanceEndFrame = parsePositiveInt(
+  "SKIRMISH_REPLAY_PERFORMANCE_END_FRAME", Number.MAX_SAFE_INTEGER);
 const expectScorchProbe = process.env.SKIRMISH_START_SCORCH_PROBE === "1";
 const expectParticleVisibilityProbe =
   process.env.SKIRMISH_START_PARTICLE_VISIBILITY_PROBE === "1";
@@ -110,6 +128,12 @@ if ((requestedModLocalPath || requestedModLocalDir) && !requestedModPackage) {
 }
 if (requestedModLocalPath && requestedModLocalDir) {
   throw new Error("Choose either SKIRMISH_START_MOD_LOCAL_PATH or SKIRMISH_START_MOD_LOCAL_DIR");
+}
+if (expectReplayPerformance && !retailReplayFixture) {
+  throw new Error("SKIRMISH_START_REPLAY_PERFORMANCE requires SKIRMISH_REPLAY_FIXTURE");
+}
+if (expectReplayPerformance && replayPerformanceClientFps < replayPerformanceLogicFps) {
+  throw new Error("Replay performance client FPS must be at least the logic FPS");
 }
 
 function parsePositiveInt(name, fallback) {
@@ -152,6 +176,7 @@ function compactGameplay(frame) {
   return {
     framesCompleted: frame?.framesCompleted ?? null,
     gameMode: gameplay?.gameMode ?? null,
+    logicFrame: gameplay?.logicFrame ?? null,
     inGame: gameplay?.inGame ?? null,
     loadingMap: gameplay?.loadingMap ?? null,
     objectCount: gameplay?.objectCount ?? null,
@@ -161,6 +186,7 @@ function compactGameplay(frame) {
     localPlayer: gameplay?.localPlayer ?? null,
     ai: gameplay?.ai ?? null,
     playerDiagnostics: gameplay?.playerDiagnostics ?? null,
+    recorder: gameplay?.recorder ?? null,
     display,
   };
 }
@@ -1177,6 +1203,347 @@ async function driveReplayRoundTrip(page) {
   };
 }
 
+function replayFrameDuration(bytes) {
+  expect(bytes.length >= 18 && bytes.subarray(0, 6).toString("ascii") === "GENREP",
+    "retail replay fixture has an invalid header", { bytes: bytes.length });
+  const frames = bytes.readUInt32LE(14);
+  expect(frames > 0, "retail replay fixture does not declare a completed duration", { frames });
+  return frames;
+}
+
+function performanceDistribution(values) {
+  const finite = values.filter(Number.isFinite).sort((a, b) => a - b);
+  const percentile = (fraction) => finite.length === 0
+    ? null
+    : finite[Math.min(finite.length - 1, Math.floor((finite.length - 1) * fraction))];
+  return {
+    count: finite.length,
+    p50Ms: percentile(0.5),
+    p95Ms: percentile(0.95),
+    p99Ms: percentile(0.99),
+    maxMs: finite.at(-1) ?? null,
+    over16_7Ms: finite.filter((value) => value > 1000 / 60).length,
+    over33_3Ms: finite.filter((value) => value > 1000 / 30).length,
+    over50Ms: finite.filter((value) => value > 50).length,
+    over100Ms: finite.filter((value) => value > 100).length,
+  };
+}
+
+async function importPerformanceReplay(page) {
+  const fixturePath = resolve(retailReplayFixture);
+  const fixtureBytes = await readFile(fixturePath);
+  const expectedLogicFrames = replayFrameDuration(fixtureBytes);
+  console.error(`[skirmish-start] import performance replay (${expectedLogicFrames} frames)`);
+  const imported = await rpc(page, "importReplay", {
+    name: basename(fixturePath),
+    bytesBase64: fixtureBytes.toString("base64"),
+    persist: false,
+  });
+  expect(imported?.ok === true && imported?.persisted === false,
+    "performance replay fixture could not be imported as a volatile test fixture", imported);
+  return { fixturePath, expectedLogicFrames, imported };
+}
+
+async function driveReplayPerformance(page, performanceReplay) {
+  const { fixturePath, expectedLogicFrames, imported } = performanceReplay;
+  const shellLoop = await rpc(page, "threadedStartLoop", { clientFps: 60, logicFps: 30 });
+  expect(shellLoop?.ok === true, "performance replay shell loop did not start", shellLoop);
+  await page.waitForFunction(() =>
+    Number(window.CnCPort?.state?.threadedEngine?.loop?.clientFrames ?? 0) >= 5,
+  null, { timeout: 10 * 60_000, polling: 250 });
+  const shellStopped = await rpc(page, "threadedStopLoop", { timeoutMs: 120000 });
+  expect(shellStopped?.ok === true, "performance replay shell loop did not stop", shellStopped);
+  const mainMenu = await revealMainMenu(page);
+
+  await clickButton(page, mainMenu.frame.clientState.mainMenu.buttonSinglePlayer,
+    mainMenu.frame.clientState.mainMenu.underButtonSinglePlayerCenter,
+    "performance replay single player");
+  const singlePlayerMenu = await waitForCondition(
+    page, "performance replay single-player menu",
+    (clientState) => clientState.mainMenu?.buttonLoadReplay?.clickable === true
+      || clientState.mainMenu?.buttonSingleBack?.clickable === true,
+    180);
+  if (singlePlayerMenu.frame.clientState.mainMenu.buttonLoadReplay?.clickable !== true) {
+    await clickButton(page, singlePlayerMenu.frame.clientState.mainMenu.buttonSingleBack,
+      null, "performance replay single-player back");
+  }
+  const loadReplay = singlePlayerMenu.frame.clientState.mainMenu.buttonLoadReplay?.clickable === true
+    ? singlePlayerMenu
+    : await waitForCondition(
+      page,
+      "performance replay load entry",
+      (clientState) => clientState.mainMenu?.buttonLoadReplay?.clickable === true,
+      180);
+  await clickButton(page, loadReplay.frame.clientState.mainMenu.buttonLoadReplay,
+    null, "performance replay load replay");
+  const replayButton = await waitForCondition(
+    page,
+    "performance replay list entry",
+    (clientState) => clientState.mainMenu?.buttonReplay?.clickable === true,
+    180);
+  await clickButton(page, replayButton.frame.clientState.mainMenu.buttonReplay,
+    null, "performance replay list");
+  const replayMenu = await waitForCondition(
+    page,
+    "performance replay menu populated",
+    (clientState) => clientState.replayMenu?.parent?.found === true
+      && clientState.replayMenu?.buttonLoad?.clickable === true
+      && clientState.replayMenu?.entryCount > 0,
+    240);
+  const importedDisplayName = imported.name.replace(/\.rep$/i, "");
+  expect(replayMenu.frame.clientState.replayMenu.selectedName === importedDisplayName,
+    "performance replay menu did not select the imported replay", {
+      imported: imported.name,
+      expectedDisplayName: importedDisplayName,
+      selected: replayMenu.frame.clientState.replayMenu.selectedName,
+    });
+  if (requireReplayPerformanceVisible) {
+    await page.locator("#viewport").screenshot({ path: replayMenuScreenshotPath });
+  }
+  let renderDisabled = false;
+  if (disableReplayPerformanceRender && !requireReplayPerformanceVisible) {
+    const disabled = await rpc(page, "realEngineSetRenderDisabled", { disabled: true });
+    expect(disabled?.ok === true && disabled?.disabled === true,
+      "performance replay could not disable rendering for CPU isolation", disabled);
+    renderDisabled = true;
+  }
+  await clickButton(page, replayMenu.frame.clientState.replayMenu.buttonLoad,
+    null, "performance replay play");
+  const versionPrompt = await runFrames(page, 2, "performance replay version prompt");
+  if (versionPrompt.frame.clientState.messageBox?.buttonOk?.clickable === true) {
+    await clickWindowByName(page, "MessageBox.wnd:ButtonOk",
+      "performance replay version confirmation");
+  }
+  const playback = await waitForCondition(
+    page,
+    "performance replay playback",
+    (clientState) => clientState.gameplay?.gameMode === 3
+      && clientState.gameplay?.inGame === true
+      && clientState.gameplay?.loadingMap === false
+      && clientState.gameplay?.recorder?.playback === true,
+    maxStartFrames);
+  if (requireReplayPerformanceVisible) {
+    await runFrames(page, 30, "performance replay visible playback settle");
+    await page.locator("#viewport").screenshot({ path: replayPlaybackScreenshotPath });
+  }
+  const startRenderProbe = requireReplayPerformanceVisible
+    ? await sampleViewportGrid(page)
+    : null;
+  if (requireReplayPerformanceVisible) {
+    expect(startRenderProbe.ok === true && startRenderProbe.visibleSampleCount > 0
+        && startRenderProbe.uniqueColorCount > 1,
+      "performance replay start frame is not visibly rendered", startRenderProbe);
+  }
+  if (disableReplayPerformanceRender && !renderDisabled) {
+    const disabled = await rpc(page, "realEngineSetRenderDisabled", { disabled: true });
+    expect(disabled?.ok === true && disabled?.disabled === true,
+      "performance replay could not disable rendering for CPU isolation", disabled);
+    renderDisabled = true;
+  }
+  const profilingFrame = await rpc(page, "realEngineFrameSummary", {
+    frames: 1,
+    profile: profileReplayPerformance,
+  });
+  expect(profilingFrame?.ok === true
+      && profilingFrame.frame?.profile?.enabled === profileReplayPerformance,
+    "performance replay CPU profiling mode was not applied", profilingFrame);
+
+  await page.evaluate(() => {
+    window.__cncSetD3D8PerfCounters?.(true);
+    const capture = {
+      engineFrameMs: [],
+      presentationFrameMs: [],
+      statuses: [],
+      lastClientFrames: 0,
+      lastEngineFrameSamples: 0,
+      maxLogicFrame: 0,
+      lastReplayLogicFrame: null,
+      replayEndEngineFrameSample: null,
+      replayEnded: false,
+      replayPlaybackSeen: false,
+      crcMismatch: false,
+      slowFrameProfiles: [],
+      startedAt: null,
+    };
+    window.__cncReplayPerformanceCapture = capture;
+    window.addEventListener("cncport:threadedstatus", (event) => {
+      const status = event.detail;
+      const loop = status?.loop;
+      if (!loop || !Number.isFinite(loop.clientFrames)) return;
+      if (capture.startedAt !== loop.startedAt) {
+        capture.startedAt = loop.startedAt;
+        capture.lastClientFrames = 0;
+        capture.lastEngineFrameSamples = 0;
+      }
+      const addedClientFrames = Math.max(0, loop.clientFrames - capture.lastClientFrames);
+      const addedEngineFrames = Math.max(0,
+        Number(loop.engineFrameSamples ?? 0) - capture.lastEngineFrameSamples);
+      const appendTail = (target, source, added) => {
+        if (!Array.isArray(source) || added <= 0) return [];
+        const tail = source.slice(-Math.min(added, source.length)).filter(Number.isFinite);
+        target.push(...tail);
+        return tail;
+      };
+      const engineTimes = status.timing?.engineFrameMs;
+      const engineLogicFrames = status.timing?.engineLogicFrames;
+      const engineFrameMs = [];
+      if (Array.isArray(engineTimes) && Array.isArray(engineLogicFrames)
+          && addedEngineFrames > 0) {
+        const tailCount = Math.min(addedEngineFrames, engineTimes.length,
+          engineLogicFrames.length);
+        const firstTailIndex = engineTimes.length - tailCount;
+        const firstEngineFrameSample = Number(loop.engineFrameSamples) - tailCount + 1;
+        for (let i = firstTailIndex; i < engineTimes.length; i += 1) {
+          const frameMs = Number(engineTimes[i]);
+          const logicFrame = Number(engineLogicFrames[i]);
+          const engineFrameSample = firstEngineFrameSample + i - firstTailIndex;
+          if (!Number.isFinite(frameMs) || !Number.isFinite(logicFrame)) continue;
+          if (!capture.replayEnded && capture.lastReplayLogicFrame !== null
+              && logicFrame < capture.lastReplayLogicFrame) {
+            capture.replayEnded = true;
+            capture.replayEndEngineFrameSample = engineFrameSample;
+          }
+          if (capture.replayEnded) continue;
+          capture.lastReplayLogicFrame = logicFrame;
+          capture.engineFrameMs.push(frameMs);
+          engineFrameMs.push(frameMs);
+        }
+      }
+      const presentationFrameMs = appendTail(capture.presentationFrameMs,
+        status.timing?.presentationFrameMs, addedClientFrames);
+      capture.lastClientFrames = loop.clientFrames;
+      capture.lastEngineFrameSamples = Number(loop.engineFrameSamples ?? 0);
+      capture.maxLogicFrame = Math.max(capture.maxLogicFrame,
+        Number(status.frame?.logicFrame ?? 0));
+      const recorder = status.frame?.recorder;
+      if (loop.replayPlaybackSeen === true) {
+        capture.replayPlaybackSeen = true;
+      }
+      if (loop.crcMismatch === true) {
+        capture.crcMismatch = true;
+      }
+      if (Array.isArray(status.timing?.slowFrameProfiles)) {
+        capture.slowFrameProfiles = status.timing.slowFrameProfiles;
+      }
+      capture.statuses.push({
+        now: status.now,
+        clientFrames: loop.clientFrames,
+        engineFrameSamples: loop.engineFrameSamples ?? null,
+        logicFrames: loop.logicFrames,
+        logicFrame: status.frame?.logicFrame ?? null,
+        lastFrameMs: status.frame?.lastFrameMs ?? null,
+        recorder: recorder ?? null,
+        active: loop.active,
+        contextLost: status.contextLost,
+        renderer: status.graphics?.renderer ?? null,
+        d3d8Perf: status.graphics?.d3d8Perf ?? null,
+        engineFrameMs,
+        presentationFrameMs,
+      });
+    });
+  });
+
+  const started = await rpc(page, "threadedStartLoop", {
+    clientFps: replayPerformanceClientFps,
+    logicFps: replayPerformanceLogicFps,
+    catchup: replayPerformanceCatchup,
+    profilingEnabled: profileReplayPerformance,
+  });
+  expect(started?.ok === true, "performance replay paced loop did not start", started);
+  const targetLogicFrame = Math.min(expectedLogicFrames, replayPerformanceEndFrame);
+  const expectedWallMs = targetLogicFrame / replayPerformanceLogicFps * 1000;
+  const completionThreshold = targetLogicFrame === expectedLogicFrames
+    ? Math.max(1, expectedLogicFrames - Math.max(120, replayPerformanceLogicFps * 2))
+    : targetLogicFrame;
+  const waitForReplayEnd = targetLogicFrame === expectedLogicFrames;
+  let completionError = null;
+  try {
+    await page.waitForFunction(
+      ({ target, replayEnd }) => {
+        const capture = window.__cncReplayPerformanceCapture;
+        return replayEnd ? capture?.replayEnded === true : capture?.maxLogicFrame >= target;
+      },
+      { target: completionThreshold, replayEnd: waitForReplayEnd },
+      { timeout: Math.max(600_000, expectedWallMs * 3 + 120_000), polling: 500 });
+  } catch (error) {
+    completionError = error instanceof Error ? error.message : String(error);
+  }
+  const stopped = await rpc(page, "threadedStopLoop", { timeoutMs: 120000 });
+  const finalFrame = await runSummary(page, 1, "performance replay final state");
+  const capture = await page.evaluate(() => window.__cncReplayPerformanceCapture);
+  const endRenderProbe = requireReplayPerformanceVisible
+    ? await sampleViewportGrid(page)
+    : null;
+  const finalScreenshotPath = requireReplayPerformanceVisible ? screenshotPath : null;
+  if (finalScreenshotPath) {
+    await page.locator("#viewport").screenshot({ path: finalScreenshotPath });
+  }
+  const contextLosses = capture.statuses.filter((status) => status.contextLost === true).length;
+  expect(contextLosses === 0, "performance replay lost the WebGL context", { contextLosses });
+
+  const completed = waitForReplayEnd
+    ? capture.replayEnded === true && capture.maxLogicFrame >= completionThreshold
+    : capture.maxLogicFrame >= completionThreshold;
+  const recorder = finalFrame.frame?.gameplay?.recorder
+    ?? finalFrame.frame?.clientState?.gameplay?.recorder ?? null;
+  const deterministic = capture.replayPlaybackSeen && capture.crcMismatch === false;
+  const playbackStateValid = targetLogicFrame === expectedLogicFrames
+    || recorder?.playback === true;
+  const slowFrameProfiles = capture.slowFrameProfiles.filter((entry) =>
+    capture.replayEndEngineFrameSample === null
+      || !Number.isFinite(Number(entry?.engineFrameSample))
+      || Number(entry.engineFrameSample) < capture.replayEndEngineFrameSample);
+  const postReplaySlowFrameProfiles = capture.slowFrameProfiles.filter((entry) =>
+    capture.replayEndEngineFrameSample !== null
+      && Number.isFinite(Number(entry?.engineFrameSample))
+      && Number(entry.engineFrameSample) >= capture.replayEndEngineFrameSample);
+  return {
+    ok: completed && stopped?.ok === true && deterministic && playbackStateValid,
+    source: "skirmish-start-replay-performance",
+    fixture: fixturePath,
+    importedReplay: imported.name,
+    expectedLogicFrames,
+    clientFps: replayPerformanceClientFps,
+    logicFps: replayPerformanceLogicFps,
+    catchup: replayPerformanceCatchup,
+    targetLogicFrame,
+    visualRequired: requireReplayPerformanceVisible,
+    renderDisabled: disableReplayPerformanceRender,
+    playbackStart: compactGameplay(playback.frame),
+    finalGameplay: compactGameplay(finalFrame.frame),
+    recorder,
+    replayPlaybackSeen: capture.replayPlaybackSeen,
+    crcMismatch: capture.crcMismatch,
+    deterministic,
+    playbackStateValid,
+    timing: {
+      engine: performanceDistribution(capture.engineFrameMs),
+      presentation: performanceDistribution(capture.presentationFrameMs),
+    },
+    maxLogicFrame: capture.maxLogicFrame,
+    replayEnded: capture.replayEnded,
+    replayEndEngineFrameSample: capture.replayEndEngineFrameSample,
+    completionThreshold,
+    completionError,
+    stopResult: stopped,
+    statusSamples: capture.statuses,
+    slowFrameProfiles,
+    postReplaySlowFrameProfiles,
+    contextLosses,
+    graphics: {
+      renderer: capture.statuses.findLast((status) => status.renderer)?.renderer ?? null,
+      contextLost: contextLosses > 0,
+    },
+    startRenderProbe,
+    endRenderProbe,
+    screenshots: {
+      menu: requireReplayPerformanceVisible ? replayMenuScreenshotPath : null,
+      playbackStart: requireReplayPerformanceVisible ? replayPlaybackScreenshotPath : null,
+      final: finalScreenshotPath,
+    },
+  };
+}
+
 async function driveEscMenuResume(page) {
   const before = await runFrames(page, 1, "esc menu precheck");
   expect(before.frame?.clientState?.gameplay?.inGame === true &&
@@ -2013,7 +2380,7 @@ async function main() {
     console.error("[skirmish-start] real init");
     const init = await rpc(page, "realEngineInit", {
       runDirectory: "/assets/skirmish-start",
-      shellMap: true,
+      shellMap: !expectReplayPerformance,
       modDirectory: mount.modDirectory ?? "",
     });
     expect(init?.ok === true && init?.aborted === false && init?.frontier?.initReturned === true,
@@ -2021,6 +2388,36 @@ async function main() {
     if (activeMod) {
       expect(init.frontier.commandLine?.includes("-mod /assets/cnc-mods-active"),
         "real engine did not receive the imported mod directory", init.frontier);
+    }
+
+    if (expectReplayPerformance) {
+      const performanceReplay = await importPerformanceReplay(page);
+      const result = await driveReplayPerformance(page, performanceReplay);
+      await writeFile(outputPath, JSON.stringify(result, null, 2));
+      console.log(JSON.stringify({
+        ok: result.ok,
+        output: outputPath,
+        expectedLogicFrames: result.expectedLogicFrames,
+        completionThreshold: result.completionThreshold,
+        maxLogicFrame: result.maxLogicFrame,
+        recorder: result.recorder,
+        deterministic: result.deterministic,
+        playbackStateValid: result.playbackStateValid,
+        timing: result.timing,
+        completionError: result.completionError,
+      }, null, 2));
+      expect(result.ok, "performance replay did not complete", {
+        output: outputPath,
+        expectedLogicFrames: result.expectedLogicFrames,
+        completionThreshold: result.completionThreshold,
+        maxLogicFrame: result.maxLogicFrame,
+        recorder: result.recorder,
+        deterministic: result.deterministic,
+        playbackStateValid: result.playbackStateValid,
+        completionError: result.completionError,
+        stopResult: result.stopResult,
+      });
+      return;
     }
 
     if (expectReplayRoundTrip) {

--- a/WebAssembly/src/wasm_real_engine_init.cpp
+++ b/WebAssembly/src/wasm_real_engine_init.cpp
@@ -787,6 +787,13 @@ extern "C" EMSCRIPTEN_KEEPALIVE void cnc_port_real_engine_set_player_diagnostics
 	g_player_runtime_diagnostics_enabled = enabled != 0;
 }
 
+extern "C" EMSCRIPTEN_KEEPALIVE int cnc_port_real_engine_set_render_disabled(int disabled)
+{
+	if (TheWritableGlobalData == NULL) return 0;
+	TheWritableGlobalData->m_disableRender = disabled != 0;
+	return TheWritableGlobalData->m_disableRender == (disabled != 0) ? 1 : 0;
+}
+
 extern "C" EMSCRIPTEN_KEEPALIVE const char *cnc_port_real_engine_last_update_target()
 {
 	return g_last_engine_update_target.c_str();
@@ -801,6 +808,7 @@ extern "C" EMSCRIPTEN_KEEPALIVE void cnc_port_real_engine_set_engine_update_brea
 extern "C" void cnc_port_note_game_logic_step(const char *name)
 {
 	g_last_game_logic_step = name != nullptr ? name : "";
+	note_engine_frame_profile_marker(name);
 	if (g_last_game_logic_step.rfind("GameEngine.init.", 0) == 0
 		|| g_last_game_logic_step.rfind("GameLogic.reset.", 0) == 0
 		|| g_last_game_logic_step.rfind("W3DTerrainLogic.reset.", 0) == 0
@@ -841,6 +849,10 @@ extern "C" void cnc_port_note_script_step(
 	g_last_script_side_index = side_index;
 	g_last_script_condition_type = condition_type;
 	g_last_script_action_type = action_type;
+	if (g_engine_frame_profile_enabled && g_last_script_phase == "executeActions.action") {
+		const std::string label = "ScriptAction." + std::to_string(action_type);
+		note_engine_frame_profile_marker(label.c_str());
+	}
 }
 
 extern "C" void cnc_port_note_texture_apply(
@@ -4217,6 +4229,28 @@ void append_ai_runtime_state(std::string &json)
 	json += "}";
 }
 
+void append_recorder_state(std::string &json)
+{
+	json += ",\"recorder\":{";
+	json += "\"ready\":";
+	json += TheRecorder != NULL ? "true" : "false";
+	if (TheRecorder != NULL) {
+		json += ",\"mode\":" + std::to_string(static_cast<Int>(TheRecorder->getMode()));
+		json += ",\"recording\":";
+		json += TheRecorder->isRecording() ? "true" : "false";
+		json += ",\"playback\":";
+		json += TheRecorder->isPlayingBack() ? "true" : "false";
+		json += ",\"crcMismatch\":";
+		json += TheRecorder->sawPlaybackCRCMismatch() ? "true" : "false";
+		json += ",\"currentReplay\":\"" + json_escape(
+			TheRecorder->getCurrentReplayFilename().str()) + "\"";
+	} else {
+		json += ",\"mode\":null,\"recording\":false,\"playback\":false,"
+			"\"crcMismatch\":false,\"currentReplay\":null";
+	}
+	json += "}";
+}
+
 void append_real_engine_frame_summary_state(std::string &json)
 {
 	json += ",\"inputSettings\":{\"useAlternateMouse\":";
@@ -4258,6 +4292,7 @@ void append_real_engine_frame_summary_state(std::string &json)
 		json += "\"gameLogicReady\":false,\"inGame\":null,\"gameMode\":null,"
 			"\"logicFrame\":null,\"objectCount\":0,\"loadingMap\":null";
 	}
+	append_recorder_state(json);
 	if (TheGameClient != NULL) {
 		json += ",\"gameClientReady\":true";
 		json += ",\"clientFrame\":" + std::to_string(TheGameClient->getFrame());
@@ -5135,21 +5170,7 @@ void append_real_engine_client_state(std::string &json)
 			"\"loadingSave\":null,\"clearingGameData\":null,\"gamePaused\":null,"
 		"\"logicFrame\":null,\"objectCount\":0,\"progressComplete\":null";
 	}
-	json += ",\"recorder\":{";
-	json += "\"ready\":";
-	json += TheRecorder != NULL ? "true" : "false";
-	if (TheRecorder != NULL) {
-		json += ",\"mode\":" + std::to_string(static_cast<Int>(TheRecorder->getMode()));
-		json += ",\"recording\":";
-		json += TheRecorder->isRecording() ? "true" : "false";
-		json += ",\"playback\":";
-		json += TheRecorder->isPlayingBack() ? "true" : "false";
-		json += ",\"currentReplay\":\"" + json_escape(
-			TheRecorder->getCurrentReplayFilename().str()) + "\"";
-	} else {
-		json += ",\"mode\":null,\"recording\":false,\"playback\":false,\"currentReplay\":null";
-	}
-	json += "}";
+	append_recorder_state(json);
 	json += ",\"lifecycleDebug\":{";
 	json += "\"newGameCount\":" + std::to_string(cnc_port_logic_dispatch_new_game_count());
 	json += ",\"lastNewGameMode\":" + std::to_string(cnc_port_logic_dispatch_last_new_game_mode());
@@ -6527,6 +6548,8 @@ extern "C" EMSCRIPTEN_KEEPALIVE const char *cnc_port_real_engine_frame_paced(int
 	char elapsed[64];
 	std::snprintf(elapsed, sizeof(elapsed), ",\"lastFrameMs\":%.1f", g_frame_state.last_frame_ms);
 	json += elapsed;
+	append_recorder_state(json);
+	append_engine_frame_profile_json(json);
 	json += "}";
 	g_frame_json = json;
 	return g_frame_json.c_str();


### PR DESCRIPTION
Fixes #125.

This moves synchronous browser asset and W3D model creation into match loading, then removes the main late-game CPU stalls from pathfinding. The pathfinder keeps the original equal-cost ordering and results while using stable cost buckets, per-search scratch caches, and union/find zone materialization.

The replay harness now imports retail replays without persisting them, measures every paced engine frame, latches recorder CRC mismatches during playback, and separates replay teardown from gameplay timings.

The full render-disabled Release replay completed all 38,696 gameplay samples with no CRC mismatch:

- p50: 4.0 ms
- p95: 13.9 ms
- p99: 18.4 ms
- frames over 33.3 ms: 5, down from 475
- frames over 50 ms: 1
- frames over 100 ms: 0

Verification:

- `npm run build:port:threaded:release`
- `npm run verify:replay-file-store`
- JavaScript syntax checks for the changed harness files
- full `Slow 4vs4.rep` playback through actual replay exit with `crcMismatch=false`
- preliminary SwiftShader rendering with visible pixel probes and no context loss

This is a draft because hardware graphics verification is still pending. The NVIDIA GSP on `llmtrain` is unresponsive and needs a host reboot. SwiftShader rendered coherent gameplay but was too slow to reach the former frame 3,329 and 3,360 stall window. The branch also has a content conflict with current `dev` in `WebAssembly/harness/skirmish_start_smoke.mjs` after concurrent harness changes.

Agent-Model: OpenAI gpt-5.6-sol