### PR TITLE
Fix ShockWave battle rendering stalls

### DIFF
--- a/WebAssembly/harness/d3d8_buffer_streaming_unit.mjs
+++ b/WebAssembly/harness/d3d8_buffer_streaming_unit.mjs
@@ -497,7 +497,9 @@ const multiWorldBatch = {
     ]),
   ],
 };
-assert.equal(diag.ensureD3D8MultiWorldGeometry(multiWorldBatch), null);
+for (let observation = 0; observation < 8; observation += 1) {
+  assert.equal(diag.ensureD3D8MultiWorldGeometry(multiWorldBatch), null);
+}
 const multiWorldGeometry = diag.ensureD3D8MultiWorldGeometry(multiWorldBatch);
 assert.ok(multiWorldGeometry);
 assert.equal(multiWorldGeometry.indexCount, 12);
@@ -505,7 +507,9 @@ assert.equal(calls.copyBufferSubData.length, copyCallsBeforeMultiWorld);
 assert.equal(diag.ensureD3D8MultiWorldGeometry(multiWorldBatch), multiWorldGeometry);
 assert.equal(calls.copyBufferSubData.length, copyCallsBeforeMultiWorld);
 multiWorldBatch.worldTransforms[1][12] = 11;
-assert.equal(diag.ensureD3D8MultiWorldGeometry(multiWorldBatch), null);
+for (let observation = 0; observation < 8; observation += 1) {
+  assert.equal(diag.ensureD3D8MultiWorldGeometry(multiWorldBatch), null);
+}
 const movedMultiWorldGeometry = diag.ensureD3D8MultiWorldGeometry(multiWorldBatch);
 assert.ok(movedMultiWorldGeometry);
 assert.notEqual(movedMultiWorldGeometry, multiWorldGeometry);

--- a/WebAssembly/harness/d3d8_executor.mjs
+++ b/WebAssembly/harness/d3d8_executor.mjs
@@ -192,6 +192,7 @@ const D3D8_MULTI_WORLD_BUFFER_ID_BASE = 0x61000000;
 const D3D8_MULTI_WORLD_MAX_DRAWS = 16;
 const D3D8_MULTI_WORLD_CACHE_LIMIT = 64;
 const D3D8_MULTI_WORLD_OBSERVATION_LIMIT = 256;
+const D3D8_MULTI_WORLD_BUILD_OBSERVATIONS = 8;
 const D3D8_MULTI_WORLD_MATRIX_POOL_SIZE = 256;
 let d3d8MultiWorldBufferCounter = 0;
 let d3d8MultiWorldMatrixPoolCursor = 0;
@@ -871,6 +872,7 @@ const d3d8PerfStats = {
 };
 const d3d8DrawBatchFlushReasons = new Map();
 const d3d8FrameCommandFlushReasons = new Map();
+const d3d8FrameCommandCaptureFailures = new Map();
 
 // Per-GL-op diagnostics are useful to the harness but measurable in draw-flood
 // frames. Lite mode keeps both clocks and counters out of the human-play hot
@@ -1222,6 +1224,9 @@ function d3d8PerfSummary() {
     frameCommandReplayMs: roundedPerfMs(d3d8PerfStats.frameCommandReplayMs),
     frameCommandFlushReasons: Object.fromEntries(
       [...d3d8FrameCommandFlushReasons.entries()].sort((left, right) =>
+        right[1] - left[1] || left[0].localeCompare(right[0]))),
+    frameCommandCaptureFailures: Object.fromEntries(
+      [...d3d8FrameCommandCaptureFailures.entries()].sort((left, right) =>
         right[1] - left[1] || left[0].localeCompare(right[0]))),
     drawRepeatedGeometryBatches: d3d8PerfStats.drawRepeatedGeometryBatches,
     drawRepeatedGeometryCopies: d3d8PerfStats.drawRepeatedGeometryCopies,
@@ -3320,6 +3325,15 @@ function updateD3D8Buffer(payload = {}) {
   // take the cached whole-mirror refresh path instead (one fresh-storage
   // bufferData per actual change — still no per-draw in-flight sync).
   const discard = Boolean(resource.dynamic && (lockFlags & D3DLOCK_DISCARD));
+  if (resource.dynamic === true &&
+      d3d8FrameSourceUpdateRequiresFlush(
+        resource,
+        byteOffset,
+        requiredByteSize,
+        discard,
+      )) {
+    flushD3D8FrameCommandQueue("dynamicSourceUpdate");
+  }
   if (resource.dynamic === true &&
       (lockFlags & (D3DLOCK_DISCARD | D3DLOCK_NOOVERWRITE)) !== 0) {
     resource.dynRingPattern = true;
@@ -13785,7 +13799,11 @@ function ensureD3D8MultiWorldGeometry(batch) {
   }
   if (!cached) {
     const observations = d3d8MultiWorldGeometryObservations.get(key) ?? 0;
-    if (observations < 1) {
+    // Baking one batch transforms and uploads every source vertex on the CPU.
+    // Moving object groups can repeat briefly with the same matrix and then
+    // never reuse the result enough to repay that work. Promote only geometry
+    // observed repeatedly; stable groups still enter the cache quickly.
+    if (observations < D3D8_MULTI_WORLD_BUILD_OBSERVATIONS) {
       d3d8MultiWorldGeometryObservations.delete(key);
       d3d8MultiWorldGeometryObservations.set(key, observations + 1);
       while (d3d8MultiWorldGeometryObservations.size >
@@ -13992,14 +14010,23 @@ let d3d8FrameCommandReplayActive = false;
 let d3d8FrameNativeRepeatTemplate = null;
 let d3d8FrameVertexArenaBytes = 0;
 let d3d8FrameIndexArenaBytes = 0;
-let d3d8FrameVertexArenaChunks = [];
-let d3d8FrameIndexArenaChunks = [];
-let d3d8FrameVertexSnapshotCache = new Map();
-let d3d8FrameIndexSnapshotCache = new Map();
-let d3d8FrameDerivedSnapshotCache = new Map();
-let d3d8FrameWorldSnapshotCache = new Map();
-let d3d8FrameViewSnapshotCache = new Map();
-let d3d8FrameProjectionSnapshotCache = new Map();
+const d3d8FrameVertexArenaChunks = [];
+const d3d8FrameIndexArenaChunks = [];
+let d3d8FrameVertexArenaScratch = new Uint8Array(0);
+let d3d8FrameIndexArenaScratch = new Uint8Array(0);
+const d3d8FrameSourceRanges = new Map();
+const d3d8FrameVertexSnapshotCache = new Map();
+const d3d8FrameIndexSnapshotCache = new Map();
+const d3d8FrameDerivedSnapshotCache = new Map();
+const d3d8FrameWorldSnapshotCache = new Map();
+const d3d8FrameViewSnapshotCache = new Map();
+const d3d8FrameProjectionSnapshotCache = new Map();
+const d3d8FrameMatrixSnapshotPool = [];
+let d3d8FrameMatrixSnapshotPoolCursor = 0;
+const d3d8FrameTextureSnapshotPool = [];
+let d3d8FrameTextureSnapshotPoolCursor = 0;
+const d3d8FrameViewportSnapshotPool = [];
+let d3d8FrameViewportSnapshotPoolCursor = 0;
 
 function d3d8AdjacentDrawBatchingActive() {
   return Boolean(gl && d3d8AdjacentDrawBatchingEnabled && d3d8DiagLevel !== "full");
@@ -14819,16 +14846,21 @@ function d3d8FrameCommandQueueActiveForPayload(payload) {
 
 function d3d8FrameViewportSnapshot() {
   const viewport = currentD3D8ViewportPayload();
-  return {
-    x: Number(viewport.x ?? 0) >>> 0,
-    y: Number(viewport.y ?? 0) >>> 0,
-    width: Number(viewport.width ?? 0) >>> 0,
-    height: Number(viewport.height ?? 0) >>> 0,
-    minZ: finiteNumber(viewport.minZ, 0),
-    maxZ: finiteNumber(viewport.maxZ, 1),
-    targetWidth: Number(viewport.targetWidth ?? viewport.width ?? 0) >>> 0,
-    targetHeight: Number(viewport.targetHeight ?? viewport.height ?? 0) >>> 0,
-  };
+  let snapshot = d3d8FrameViewportSnapshotPool[d3d8FrameViewportSnapshotPoolCursor];
+  if (!snapshot) {
+    snapshot = {};
+    d3d8FrameViewportSnapshotPool.push(snapshot);
+  }
+  snapshot.x = Number(viewport.x ?? 0) >>> 0;
+  snapshot.y = Number(viewport.y ?? 0) >>> 0;
+  snapshot.width = Number(viewport.width ?? 0) >>> 0;
+  snapshot.height = Number(viewport.height ?? 0) >>> 0;
+  snapshot.minZ = finiteNumber(viewport.minZ, 0);
+  snapshot.maxZ = finiteNumber(viewport.maxZ, 1);
+  snapshot.targetWidth = Number(viewport.targetWidth ?? viewport.width ?? 0) >>> 0;
+  snapshot.targetHeight = Number(viewport.targetHeight ?? viewport.height ?? 0) >>> 0;
+  d3d8FrameViewportSnapshotPoolCursor += 1;
+  return snapshot;
 }
 
 function d3d8FrameViewportsEqual(left, right) {
@@ -14843,6 +14875,33 @@ function d3d8FrameViewportsEqual(left, right) {
     left.targetHeight === right.targetHeight;
 }
 
+function d3d8FrameMatrixSnapshotFromPointer(pointer) {
+  let snapshot = d3d8FrameMatrixSnapshotPool[d3d8FrameMatrixSnapshotPoolCursor];
+  if (!snapshot) {
+    snapshot = new Float32Array(16);
+    d3d8FrameMatrixSnapshotPool.push(snapshot);
+    if (d3d8PerfCountersEnabled) d3d8PerfStats.drawMatrixAllocatedCopies += 1;
+  }
+  if (!copyD3DMatrixFromHeap(pointer, snapshot)) {
+    return null;
+  }
+  d3d8FrameMatrixSnapshotPoolCursor += 1;
+  return snapshot;
+}
+
+function d3d8FrameTextureSnapshot() {
+  let snapshot = d3d8FrameTextureSnapshotPool[d3d8FrameTextureSnapshotPoolCursor];
+  if (!snapshot) {
+    snapshot = new Uint32Array(D3D8_TEXTURE_STAGE_COUNT);
+    d3d8FrameTextureSnapshotPool.push(snapshot);
+  }
+  for (let stage = 0; stage < snapshot.length; stage += 1) {
+    snapshot[stage] = Number(d3d8BoundTextures.get(stage) ?? 0) >>> 0;
+  }
+  d3d8FrameTextureSnapshotPoolCursor += 1;
+  return snapshot;
+}
+
 function d3d8FrameMatrixSnapshot(value, revision, cache, required = false) {
   const pointer = Number(value ?? 0) >>> 0;
   if (pointer === 0) {
@@ -14855,11 +14914,10 @@ function d3d8FrameMatrixSnapshot(value, revision, cache, required = false) {
       return cached;
     }
   }
-  const matrix = normalizeD3DMatrix(pointer);
-  if (!matrix) {
+  const snapshot = d3d8FrameMatrixSnapshotFromPointer(pointer);
+  if (!snapshot) {
     return undefined;
   }
-  const snapshot = Float32Array.from(matrix);
   if (safeRevision !== 0) {
     cache.set(safeRevision, snapshot);
   }
@@ -14883,20 +14941,24 @@ function d3d8FrameDerivedSnapshot(payload) {
   if (!renderState || !clipPlanes || !lights || !material) {
     return null;
   }
-  const textureMatrix = (value) => {
+  const textureMatrix = (value, stage) => {
+    if (renderState.textureStages[stage].textureTransformFlags === 0) {
+      return null;
+    }
     const pointer = Number(value ?? 0) >>> 0;
     if (pointer === 0) {
       return null;
     }
-    const matrix = normalizeD3DMatrix(pointer);
-    return matrix ? Float32Array.from(matrix) : undefined;
+    const snapshot = new Float32Array(16);
+    if (d3d8PerfCountersEnabled) d3d8PerfStats.drawMatrixAllocatedCopies += 1;
+    return copyD3DMatrixFromHeap(pointer, snapshot) ? snapshot : undefined;
   };
   const transforms = {
-    texture0: textureMatrix(payload.transforms?.texture0),
-    texture1: textureMatrix(payload.transforms?.texture1),
-    texture2: textureMatrix(payload.transforms?.texture2),
-    texture3: textureMatrix(payload.transforms?.texture3),
-    texture4: textureMatrix(payload.transforms?.texture4),
+    texture0: textureMatrix(payload.transforms?.texture0, 0),
+    texture1: textureMatrix(payload.transforms?.texture1, 1),
+    texture2: textureMatrix(payload.transforms?.texture2, 2),
+    texture3: textureMatrix(payload.transforms?.texture3, 3),
+    texture4: textureMatrix(payload.transforms?.texture4, 4),
   };
   if (Object.values(transforms).some((value) => value === undefined)) {
     return null;
@@ -14931,6 +14993,31 @@ function d3d8FrameSnapshotCacheKey(resource, byteOffset, byteSize) {
     `:${byteOffset}:${byteSize}`;
 }
 
+function d3d8FrameSourceUpdateRequiresFlush(resource, updateStart, updateEnd, discard) {
+  const ranges = d3d8FrameSourceRanges.get(resource);
+  if (!ranges) {
+    return false;
+  }
+  return discard || ranges.some(
+    (range) => range.start < updateEnd && updateStart < range.end,
+  );
+}
+
+function d3d8FrameNoteSourceRange(resource, start, end) {
+  let ranges = d3d8FrameSourceRanges.get(resource);
+  if (!ranges) {
+    ranges = [];
+    d3d8FrameSourceRanges.set(resource, ranges);
+  }
+  const previous = ranges[ranges.length - 1];
+  if (previous && start <= previous.end && previous.start <= end) {
+    previous.start = Math.min(previous.start, start);
+    previous.end = Math.max(previous.end, end);
+  } else {
+    ranges.push({ start, end });
+  }
+}
+
 function d3d8FrameSnapshotDynamicRange(resource, byteOffset, byteSize, kind) {
   if (!resource?.dynamic) {
     return { id: Number(resource?.id ?? 0) >>> 0, byteOffset };
@@ -14954,22 +15041,27 @@ function d3d8FrameSnapshotDynamicRange(resource, byteOffset, byteSize, kind) {
   if (arenaOffset + byteSize > D3D8_FRAME_COMMAND_MAX_ARENA_BYTES) {
     return null;
   }
-  const bytes = resource.bytes.slice(byteOffset, end);
+  // The update path flushes before DISCARD or an overlapping write, so the
+  // CPU mirror remains immutable until this segment is materialized.
   const entry = {
     id: vertex ? D3D8_FRAME_VERTEX_ARENA_ID : D3D8_FRAME_INDEX_ARENA_ID,
     byteOffset: arenaOffset,
+    sourceResource: resource,
+    sourceByteOffset: byteOffset,
+    byteLength: byteSize,
   };
+  d3d8FrameNoteSourceRange(resource, byteOffset, end);
   cache.set(cacheKey, entry);
   if (vertex) {
-    d3d8FrameVertexArenaChunks.push({ byteOffset: arenaOffset, bytes });
-    d3d8FrameVertexArenaBytes = arenaOffset + bytes.byteLength;
+    d3d8FrameVertexArenaChunks.push(entry);
+    d3d8FrameVertexArenaBytes = arenaOffset + byteSize;
   } else {
-    d3d8FrameIndexArenaChunks.push({ byteOffset: arenaOffset, bytes });
-    d3d8FrameIndexArenaBytes = arenaOffset + bytes.byteLength;
+    d3d8FrameIndexArenaChunks.push(entry);
+    d3d8FrameIndexArenaBytes = arenaOffset + byteSize;
   }
   if (d3d8PerfCountersEnabled) {
     d3d8PerfStats.frameCommandDynamicSnapshots += 1;
-    d3d8PerfStats.frameCommandDynamicSnapshotBytes += bytes.byteLength;
+    d3d8PerfStats.frameCommandDynamicSnapshotBytes += byteSize;
   }
   return entry;
 }
@@ -15012,6 +15104,26 @@ function d3d8EnsureFrameArenaResource(kind) {
   return resource;
 }
 
+function d3d8FrameArenaScratch(kind, byteLength) {
+  const vertex = kind === 1;
+  let scratch = vertex ? d3d8FrameVertexArenaScratch : d3d8FrameIndexArenaScratch;
+  if (scratch.byteLength < byteLength) {
+    let capacity = Math.max(1024, scratch.byteLength);
+    while (capacity < byteLength) {
+      capacity *= 2;
+    }
+    scratch = new Uint8Array(capacity);
+    if (vertex) {
+      d3d8FrameVertexArenaScratch = scratch;
+    } else {
+      d3d8FrameIndexArenaScratch = scratch;
+    }
+  }
+  return scratch.byteLength === byteLength
+    ? scratch
+    : scratch.subarray(0, byteLength);
+}
+
 function d3d8MaterializeFrameArena(kind, byteLength, chunks) {
   if (byteLength === 0) {
     return true;
@@ -15020,9 +15132,17 @@ function d3d8MaterializeFrameArena(kind, byteLength, chunks) {
   if (!resource) {
     return false;
   }
-  const bytes = new Uint8Array(byteLength);
+  // WebGL copies ArrayBufferView contents before bufferData returns. Reuse a
+  // grow-only CPU staging store instead of allocating two large backing stores
+  // for every internal frame-command segment.
+  const bytes = d3d8FrameArenaScratch(kind, byteLength);
   for (const chunk of chunks) {
-    bytes.set(chunk.bytes, chunk.byteOffset);
+    const source = chunk.sourceResource?.bytes;
+    const sourceEnd = chunk.sourceByteOffset + chunk.byteLength;
+    if (!(source instanceof Uint8Array) || sourceEnd > source.byteLength) {
+      return false;
+    }
+    bytes.set(source.subarray(chunk.sourceByteOffset, sourceEnd), chunk.byteOffset);
   }
   const uploadStartedAt = perfNow();
   if (kind === 1) {
@@ -15048,14 +15168,18 @@ function d3d8ResetFrameCommandSegment() {
   d3d8FrameNativeRepeatTemplate = null;
   d3d8FrameVertexArenaBytes = 0;
   d3d8FrameIndexArenaBytes = 0;
-  d3d8FrameVertexArenaChunks = [];
-  d3d8FrameIndexArenaChunks = [];
-  d3d8FrameVertexSnapshotCache = new Map();
-  d3d8FrameIndexSnapshotCache = new Map();
-  d3d8FrameDerivedSnapshotCache = new Map();
-  d3d8FrameWorldSnapshotCache = new Map();
-  d3d8FrameViewSnapshotCache = new Map();
-  d3d8FrameProjectionSnapshotCache = new Map();
+  d3d8FrameVertexArenaChunks.length = 0;
+  d3d8FrameIndexArenaChunks.length = 0;
+  d3d8FrameSourceRanges.clear();
+  d3d8FrameVertexSnapshotCache.clear();
+  d3d8FrameIndexSnapshotCache.clear();
+  d3d8FrameDerivedSnapshotCache.clear();
+  d3d8FrameWorldSnapshotCache.clear();
+  d3d8FrameViewSnapshotCache.clear();
+  d3d8FrameProjectionSnapshotCache.clear();
+  d3d8FrameMatrixSnapshotPoolCursor = 0;
+  d3d8FrameTextureSnapshotPoolCursor = 0;
+  d3d8FrameViewportSnapshotPoolCursor = 0;
 }
 
 function d3d8FrameNativeRepeatEligible(command) {
@@ -15080,6 +15204,16 @@ function d3d8FrameNativeRepeatEligible(command) {
   );
 }
 
+function failD3D8FrameCommandCapture(reason) {
+  if (d3d8PerfCountersEnabled) {
+    d3d8FrameCommandCaptureFailures.set(
+      reason,
+      (d3d8FrameCommandCaptureFailures.get(reason) ?? 0) + 1,
+    );
+  }
+  return false;
+}
+
 function queueD3D8FrameCommand(payload, drawSequence) {
   const captureStartedAt = perfNow();
   const vertexBufferId = Number(payload.vertexBufferId ?? 0) >>> 0;
@@ -15092,7 +15226,7 @@ function queueD3D8FrameCommand(payload, drawSequence) {
   const indexResource = d3d8Buffers.get(d3d8BufferKey(2, indexBufferId));
   if (!vertexResource?.buffer || !indexResource?.buffer ||
       vertexByteSize === 0 || indexByteSize === 0) {
-    return false;
+    return failD3D8FrameCommandCapture("geometry");
   }
 
   const requiredArenaBytes =
@@ -15107,12 +15241,12 @@ function queueD3D8FrameCommand(payload, drawSequence) {
   if (vertexResource.dynamic &&
       (!(vertexResource.bytes instanceof Uint8Array) ||
        vertexByteOffset + vertexByteSize > vertexResource.bytes.byteLength)) {
-    return false;
+    return failD3D8FrameCommandCapture("vertexMirror");
   }
   if (indexResource.dynamic &&
       (!(indexResource.bytes instanceof Uint8Array) ||
        indexByteOffset + indexByteSize > indexResource.bytes.byteLength)) {
-    return false;
+    return failD3D8FrameCommandCapture("indexMirror");
   }
 
   const derived = d3d8FrameDerivedSnapshot(payload);
@@ -15136,7 +15270,7 @@ function queueD3D8FrameCommand(payload, drawSequence) {
     (transformMask & 4) !== 0,
   );
   if (!derived || world === undefined || view === undefined || projection === undefined) {
-    return false;
+    return failD3D8FrameCommandCapture("state");
   }
 
   const vertexSnapshot = d3d8FrameSnapshotDynamicRange(
@@ -15151,8 +15285,11 @@ function queueD3D8FrameCommand(payload, drawSequence) {
     indexByteSize,
     2,
   );
-  if (!vertexSnapshot || !indexSnapshot) {
-    return false;
+  if (!vertexSnapshot) {
+    return failD3D8FrameCommandCapture("vertexSnapshot");
+  }
+  if (!indexSnapshot) {
+    return failD3D8FrameCommandCapture("indexSnapshot");
   }
 
   const treeShroud = payload.treeShroud
@@ -15188,10 +15325,7 @@ function queueD3D8FrameCommand(payload, drawSequence) {
   const command = {
     payload: queuedPayload,
     viewport: d3d8FrameViewportSnapshot(),
-    textureIds: Uint32Array.from(
-      { length: D3D8_TEXTURE_STAGE_COUNT },
-      (_, stage) => Number(d3d8BoundTextures.get(stage) ?? 0) >>> 0,
-    ),
+    textureIds: d3d8FrameTextureSnapshot(),
   };
   d3d8FrameCommands.push(command);
   d3d8FrameNativeRepeatTemplate = d3d8FrameNativeRepeatEligible(command) ? command : null;
@@ -15531,16 +15665,20 @@ function paintD3D8DrawIndexed(payload = {}) {
   const projectionRevisionUnchanged = projectionRevision !== 0 &&
     projectionRevision === d3d8LastTransformSourceProjectionRevision &&
     d3d8LastTransformSourceProjection !== null;
+  // Queued matrices are immutable snapshots from the segment pool. Retain
+  // those arrays directly during replay instead of copying three 4x4 matrices
+  // into draw scratch storage again.
+  const frameMatrixScratch = queuedSequence !== 0 ? null : d3d8DrawMatrixScratch;
   const world = earlyBatchInfo?.worldTransform ??
     (worldRevisionUnchanged
       ? d3d8LastTransformSourceWorld
-      : normalizeD3DMatrix(payload.transforms?.world, d3d8DrawMatrixScratch.world));
+      : normalizeD3DMatrix(payload.transforms?.world, frameMatrixScratch?.world));
   const engineView = viewRevisionUnchanged
     ? d3d8LastTransformSourceView
-    : normalizeD3DMatrix(payload.transforms?.view, d3d8DrawMatrixScratch.view);
+    : normalizeD3DMatrix(payload.transforms?.view, frameMatrixScratch?.view);
   const engineProjection = projectionRevisionUnchanged
     ? d3d8LastTransformSourceProjection
-    : normalizeD3DMatrix(payload.transforms?.projection, d3d8DrawMatrixScratch.projection);
+    : normalizeD3DMatrix(payload.transforms?.projection, frameMatrixScratch?.projection);
   const view = d3d8XrViewOverride && engineView
     ? multiplyD3D8ColumnMatrices(
       d3d8XrViewOverride.viewPrefix,

--- a/WebAssembly/harness/d3d8_sm1_transform_switch_smoke.mjs
+++ b/WebAssembly/harness/d3d8_sm1_transform_switch_smoke.mjs
@@ -863,18 +863,18 @@ try {
     );
     globalThis.__cncSetD3D8FrameCommandQueue?.(false);
 
-    // Deferred render segments must snapshot DISCARD-updated dynamic geometry
-    // before the engine reuses its ring offsets, upload one vertex/index arena,
-    // and replay both draws in order. The second full-screen triangle is green,
-    // proving that the first red snapshot was not aliased by the later update.
+    // Deferred dynamic geometry retains a zero-copy mirror reference until
+    // frame-arena materialization. An overlapping DISCARD must replay the red
+    // segment before the mirror turns green, preserving both viewport draws.
     const frameVertexBufferId = 900;
     const frameIndexBufferId = 901;
     const dynamicUsage = 0x208; // D3DUSAGE_DYNAMIC | D3DUSAGE_WRITEONLY
     const discardLock = 0x2000; // D3DLOCK_DISCARD
+    const noOverwriteLock = 0x1000; // D3DLOCK_NOOVERWRITE
     expect(hooks.cncPortD3D8BufferCreate({
       kind: 1,
       id: frameVertexBufferId,
-      byteSize: 48,
+      byteSize: 96,
       usage: dynamicUsage,
     }) === 1, "frame-command vertex buffer creation failed");
     expect(hooks.cncPortD3D8BufferCreate({
@@ -899,9 +899,13 @@ try {
     }) === 1, "frame-command index upload failed");
     heapF32.set(identity, worldPtr >>> 2);
     worldTransformRevision += 1;
-    const drawFrameCommand = (hash, spatialUi = false) => hooks.cncPortD3D8DrawIndexed({
+    const drawFrameCommand = (
+      hash,
+      spatialUi = false,
+      vertexByteOffset = 0,
+    ) => hooks.cncPortD3D8DrawIndexed({
       vertexBufferId: frameVertexBufferId,
-      vertexByteOffset: 0,
+      vertexByteOffset,
       vertexBytes: 48,
       vertexCount: 3,
       vertexStride: 16,
@@ -936,6 +940,87 @@ try {
       derivedStateHash: hash,
       spatialUi,
     });
+
+    // NOOVERWRITE appends outside every referenced range can stay deferred in
+    // one segment; materialization reads both ranges before the ring is reused.
+    hooks.cncPortD3D8Clear(3, 0, 0, 0, 255, 1, 0);
+    globalThis.__cncSetD3D8FrameCommandQueue?.(true);
+    hooks.cncPortD3D8SetViewport({
+      x: 0,
+      y: 0,
+      width: 32,
+      height: 64,
+      minZ: 0,
+      maxZ: 1,
+      targetWidth: 64,
+      targetHeight: 64,
+    });
+    const beforeNonOverlappingCommands = diag.d3d8PerfSummary();
+    expect(drawFrameCommand(800) === 1,
+      "frame-command non-overlapping red draw queue failed");
+    expect(hooks.cncPortD3D8BufferUpdate({
+      kind: 1,
+      id: frameVertexBufferId,
+      byteOffset: 48,
+      bytes: makeTriangle([0, 255, 0, 255]),
+      lockFlags: noOverwriteLock,
+    }) === 1, "frame-command non-overlapping green vertex upload failed");
+    hooks.cncPortD3D8SetViewport({
+      x: 32,
+      y: 0,
+      width: 32,
+      height: 64,
+      minZ: 0,
+      maxZ: 1,
+      targetWidth: 64,
+      targetHeight: 64,
+    });
+    expect(drawFrameCommand(800, true, 48) === 1,
+      "frame-command non-overlapping green draw queue failed");
+    const queuedNonOverlappingCommands = diag.d3d8PerfSummary();
+    expect(queuedNonOverlappingCommands.frameCommandSegments ===
+        beforeNonOverlappingCommands.frameCommandSegments,
+      "non-overlapping NOOVERWRITE update flushed the deferred segment", {
+        beforeNonOverlappingCommands,
+        queuedNonOverlappingCommands,
+      });
+    diag.flushD3D8FrameCommandQueue("frame-command-non-overlap-smoke");
+    const afterNonOverlappingCommands = diag.d3d8PerfSummary();
+    expect(afterNonOverlappingCommands.frameCommandReplayedDraws ===
+        beforeNonOverlappingCommands.frameCommandReplayedDraws + 2,
+      "non-overlapping dynamic frame-command replay lost a draw", {
+        beforeNonOverlappingCommands,
+        afterNonOverlappingCommands,
+      });
+    expect(afterNonOverlappingCommands.frameCommandArenaUploads ===
+        beforeNonOverlappingCommands.frameCommandArenaUploads + 2,
+      "non-overlapping dynamic draws did not share one arena segment", {
+        beforeNonOverlappingCommands,
+        afterNonOverlappingCommands,
+      });
+    const frameNonOverlapLeftPixel = readPixel(16, 32);
+    const frameNonOverlapRightPixel = readPixel(48, 32);
+    expect(
+      frameNonOverlapLeftPixel[0] > 220 &&
+        frameNonOverlapLeftPixel[1] < 32 &&
+        frameNonOverlapLeftPixel[2] < 32 &&
+        frameNonOverlapRightPixel[0] < 32 &&
+        frameNonOverlapRightPixel[1] > 220 &&
+        frameNonOverlapRightPixel[2] < 32,
+      "non-overlapping dynamic frame-command replay aliased ring contents", {
+        frameNonOverlapLeftPixel,
+        frameNonOverlapRightPixel,
+      },
+    );
+    globalThis.__cncSetD3D8FrameCommandQueue?.(false);
+    expect(hooks.cncPortD3D8BufferUpdate({
+      kind: 1,
+      id: frameVertexBufferId,
+      byteOffset: 0,
+      bytes: makeTriangle([255, 0, 0, 255]),
+      lockFlags: discardLock,
+    }) === 1, "frame-command overlap smoke red restore failed");
+
     hooks.cncPortD3D8Clear(3, 0, 0, 0, 255, 1, 0);
     globalThis.__cncSetD3D8FrameCommandQueue?.(true);
     hooks.cncPortD3D8SetViewport({
@@ -972,32 +1057,39 @@ try {
     const queuedFrameCommands = diag.d3d8PerfSummary();
     expect(queuedFrameCommands.frameCommandQueuedDraws ===
         beforeFrameCommands.frameCommandQueuedDraws + 2,
-      "frame-command draws were not deferred", {
+      "dynamic frame-command draws were not deferred", {
         beforeFrameCommands,
         queuedFrameCommands,
       });
-    expect(queuedFrameCommands.frameCommandSegments === beforeFrameCommands.frameCommandSegments,
-      "dynamic buffer update flushed the deferred segment", {
+    expect(queuedFrameCommands.frameCommandImmediateDraws ===
+        beforeFrameCommands.frameCommandImmediateDraws,
+      "dynamic frame-command draws unexpectedly used the immediate path", {
+        beforeFrameCommands,
+        queuedFrameCommands,
+      });
+    expect(queuedFrameCommands.frameCommandSegments ===
+        beforeFrameCommands.frameCommandSegments + 1,
+      "overlapping dynamic update did not replay the protected source segment", {
         beforeFrameCommands,
         queuedFrameCommands,
       });
     diag.flushD3D8FrameCommandQueue("frame-command-smoke");
     const afterFrameCommands = diag.d3d8PerfSummary();
     expect(afterFrameCommands.frameCommandSegments ===
-        beforeFrameCommands.frameCommandSegments + 1,
-      "frame-command segment did not replay", {
+        beforeFrameCommands.frameCommandSegments + 2,
+      "dynamic frame-command segments did not replay", {
         beforeFrameCommands,
         afterFrameCommands,
       });
     expect(afterFrameCommands.frameCommandReplayedDraws ===
         beforeFrameCommands.frameCommandReplayedDraws + 2,
-      "frame-command segment lost a draw", {
+      "dynamic frame-command replay lost a draw", {
         beforeFrameCommands,
         afterFrameCommands,
       });
     expect(afterFrameCommands.frameCommandArenaUploads ===
-        beforeFrameCommands.frameCommandArenaUploads + 2,
-      "frame-command segment did not collapse geometry into two arena uploads", {
+        beforeFrameCommands.frameCommandArenaUploads + 4,
+      "dynamic frame-command segments did not materialize both arenas", {
         beforeFrameCommands,
         afterFrameCommands,
       });

--- a/WebAssembly/harness/engine_realm_boot.mjs
+++ b/WebAssembly/harness/engine_realm_boot.mjs
@@ -1117,6 +1117,8 @@ export default async function setupEngineRealm({ canvas, Module, realm, options 
         loadSessionActive: result.loadSessionActive,
         loadProgress: result.loadProgress,
         worldScene: result.worldScene ?? null,
+        display: result.display ?? null,
+        particles: result.particles ?? null,
         lastFrameMs: result.lastFrameMs,
         quitting: result.quitting,
         recorder: result.recorder ?? null,

--- a/WebAssembly/harness/skirmish_start_smoke.mjs
+++ b/WebAssembly/harness/skirmish_start_smoke.mjs
@@ -110,10 +110,21 @@ const requireReplayPerformanceVisible =
 const disableReplayPerformanceRender =
   process.env.SKIRMISH_REPLAY_PERFORMANCE_DISABLE_RENDER === "1";
 const profileReplayPerformance =
-  process.env.SKIRMISH_REPLAY_PERFORMANCE_PROFILE !== "0";
+  process.env.SKIRMISH_REPLAY_PERFORMANCE_PROFILE === "1";
+const replayPerformanceCounters =
+  process.env.SKIRMISH_REPLAY_PERFORMANCE_COUNTERS !== "0";
+const replayPerformanceGpuTiming =
+  process.env.SKIRMISH_REPLAY_PERFORMANCE_GPU_TIMING === "1";
 const requestedD3D8Batch = String(process.env.SKIRMISH_START_D3D8_BATCH ?? "").trim();
 if (requestedD3D8Batch && !/^(?:0|1|false|true|off|on)$/.test(requestedD3D8Batch)) {
   throw new Error(`Invalid SKIRMISH_START_D3D8_BATCH: ${requestedD3D8Batch}`);
+}
+const requestedD3D8FrameQueue =
+  String(process.env.SKIRMISH_START_D3D8_FRAME_QUEUE ?? "").trim();
+if (requestedD3D8FrameQueue &&
+    !/^(?:0|1|false|true|off|on)$/.test(requestedD3D8FrameQueue)) {
+  throw new Error(
+    `Invalid SKIRMISH_START_D3D8_FRAME_QUEUE: ${requestedD3D8FrameQueue}`);
 }
 const replayPerformanceClientFps = parsePositiveInt(
   "SKIRMISH_REPLAY_PERFORMANCE_CLIENT_FPS", 60);
@@ -123,6 +134,23 @@ const replayPerformanceCatchup = parsePositiveInt(
   "SKIRMISH_REPLAY_PERFORMANCE_CATCHUP", 2);
 const replayPerformanceEndFrame = parsePositiveInt(
   "SKIRMISH_REPLAY_PERFORMANCE_END_FRAME", Number.MAX_SAFE_INTEGER);
+const replayPerformanceRenderStartFrame = parsePositiveInt(
+  "SKIRMISH_REPLAY_PERFORMANCE_RENDER_START_FRAME", 0);
+const replayPerformanceMeasureStartFrame = parsePositiveInt(
+  "SKIRMISH_REPLAY_PERFORMANCE_MEASURE_START_FRAME",
+  replayPerformanceRenderStartFrame);
+const replayPerformanceRenderGateText =
+  String(process.env.SKIRMISH_REPLAY_PERFORMANCE_RENDER_GATE_FILE ?? "").trim();
+const replayPerformanceRenderGate =
+  replayPerformanceRenderGateText ? resolve(replayPerformanceRenderGateText) : null;
+const replayPerformanceRenderGateTimeoutMs = parsePositiveInt(
+  "SKIRMISH_REPLAY_PERFORMANCE_RENDER_GATE_TIMEOUT_MS", 0);
+const replayPerformanceMeasuredClientFps = parsePositiveInt(
+  "SKIRMISH_REPLAY_PERFORMANCE_MEASURE_CLIENT_FPS", replayPerformanceClientFps);
+const replayPerformanceMeasuredLogicFps = parsePositiveInt(
+  "SKIRMISH_REPLAY_PERFORMANCE_MEASURE_LOGIC_FPS", replayPerformanceLogicFps);
+const replayPerformanceMeasuredCatchup = parsePositiveInt(
+  "SKIRMISH_REPLAY_PERFORMANCE_MEASURE_CATCHUP", replayPerformanceCatchup);
 const replayPerformanceGpuProfileStartFrame = parsePositiveInt(
   "SKIRMISH_REPLAY_PERFORMANCE_GPU_PROFILE_START_FRAME", 0);
 const replayPerformanceGpuProfileFrames = parsePositiveInt(
@@ -170,6 +198,10 @@ if (expectReplayPerformance && !retailReplayFixture) {
 }
 if (expectReplayPerformance && replayPerformanceClientFps < replayPerformanceLogicFps) {
   throw new Error("Replay performance client FPS must be at least the logic FPS");
+}
+if (expectReplayPerformance &&
+    replayPerformanceMeasuredClientFps < replayPerformanceMeasuredLogicFps) {
+  throw new Error("Replay performance measured client FPS must be at least the logic FPS");
 }
 
 function parsePositiveInt(name, fallback) {
@@ -1659,6 +1691,16 @@ function performanceDistribution(values) {
   };
 }
 
+async function resetReplayPerformanceCapture(page) {
+  await page.evaluate(() => {
+    const capture = window.__cncReplayPerformanceCapture;
+    capture.engineFrameMs = [];
+    capture.presentationFrameMs = [];
+    capture.statuses = [];
+    capture.slowFrameProfiles = [];
+  });
+}
+
 async function importPerformanceReplay(page) {
   const fixturePath = resolve(retailReplayFixture);
   const fixtureBytes = await readFile(fixturePath);
@@ -1765,10 +1807,11 @@ async function driveReplayPerformance(page, performanceReplay) {
         && startRenderProbe.uniqueColorCount > 1,
       "performance replay start frame is not visibly rendered", startRenderProbe);
   }
-  if (disableReplayPerformanceRender && !renderDisabled) {
+  if ((disableReplayPerformanceRender || replayPerformanceRenderStartFrame > 0)
+      && !renderDisabled) {
     const disabled = await rpc(page, "realEngineSetRenderDisabled", { disabled: true });
     expect(disabled?.ok === true && disabled?.disabled === true,
-      "performance replay could not disable rendering for CPU isolation", disabled);
+      "performance replay could not disable rendering for warm-up", disabled);
     renderDisabled = true;
   }
   const profilingFrame = await rpc(page, "realEngineFrameSummary", {
@@ -1779,8 +1822,8 @@ async function driveReplayPerformance(page, performanceReplay) {
       && profilingFrame.frame?.profile?.enabled === profileReplayPerformance,
     "performance replay CPU profiling mode was not applied", profilingFrame);
 
-  await page.evaluate(() => {
-    window.__cncSetD3D8PerfCounters?.(true);
+  await page.evaluate((countersEnabled) => {
+    window.__cncSetD3D8PerfCounters?.(countersEnabled);
     const capture = {
       engineFrameMs: [],
       presentationFrameMs: [],
@@ -1863,6 +1906,8 @@ async function driveReplayPerformance(page, performanceReplay) {
         logicFrames: loop.logicFrames,
         logicFrame: status.frame?.logicFrame ?? null,
         lastFrameMs: status.frame?.lastFrameMs ?? null,
+        display: status.frame?.display ?? null,
+        particles: status.frame?.particles ?? null,
         recorder: recorder ?? null,
         active: loop.active,
         contextLost: status.contextLost,
@@ -1872,7 +1917,7 @@ async function driveReplayPerformance(page, performanceReplay) {
         presentationFrameMs,
       });
     });
-  });
+  }, replayPerformanceCounters);
 
   const started = await rpc(page, "threadedStartLoop", {
     clientFps: replayPerformanceClientFps,
@@ -1898,8 +1943,76 @@ async function driveReplayPerformance(page, performanceReplay) {
     { target, replayEnd },
     { timeout: waitTimeout, polling: 500 });
   let completionError = null;
+  let renderWarmup = null;
   let gpuProfile = null;
   try {
+    if (replayPerformanceRenderStartFrame > 0
+        && replayPerformanceRenderStartFrame < completionThreshold) {
+      await waitForCapture(replayPerformanceRenderStartFrame);
+      const warmupStopped = await rpc(page, "threadedStopLoop", { timeoutMs: 120000 });
+      expect(warmupStopped?.ok === true,
+        "performance replay warm-up loop did not stop", warmupStopped);
+      if (replayPerformanceRenderGate) {
+        const readyPath = `${replayPerformanceRenderGate}.ready`;
+        await writeFile(readyPath, `${replayPerformanceRenderStartFrame}\n`);
+        const deadline = Date.now() +
+          (replayPerformanceRenderGateTimeoutMs || waitTimeout);
+        while (true) {
+          try {
+            await readFile(replayPerformanceRenderGate);
+            break;
+          } catch (error) {
+            if (error?.code !== "ENOENT" || Date.now() >= deadline) {
+              throw error;
+            }
+          }
+          await new Promise((resolveDelay) => setTimeout(resolveDelay, 250));
+        }
+      }
+      const enabled = await rpc(page, "realEngineSetRenderDisabled", { disabled: false });
+      expect(enabled?.ok === true && enabled?.disabled === false,
+        "performance replay could not enable measured rendering", enabled);
+      renderDisabled = false;
+      await resetReplayPerformanceCapture(page);
+      const measuredStarted = await rpc(page, "threadedStartLoop", {
+        clientFps: replayPerformanceMeasuredClientFps,
+        logicFps: replayPerformanceMeasuredLogicFps,
+        catchup: replayPerformanceMeasuredCatchup,
+        profilingEnabled: profileReplayPerformance,
+      });
+      expect(measuredStarted?.ok === true,
+        "performance replay measured loop did not start", measuredStarted);
+      renderWarmup = {
+        endFrame: replayPerformanceRenderStartFrame,
+        clientFps: replayPerformanceClientFps,
+        logicFps: replayPerformanceLogicFps,
+        catchup: replayPerformanceCatchup,
+        stopped: warmupStopped,
+        renderGate: replayPerformanceRenderGate != null,
+        renderEnabled: enabled,
+      };
+      if (replayPerformanceMeasureStartFrame > replayPerformanceRenderStartFrame
+          && replayPerformanceMeasureStartFrame < completionThreshold) {
+        await waitForCapture(replayPerformanceMeasureStartFrame);
+        const renderWarmupStopped = await rpc(
+          page, "threadedStopLoop", { timeoutMs: 120000 });
+        expect(renderWarmupStopped?.ok === true,
+          "performance replay rendered warm-up loop did not stop",
+          renderWarmupStopped);
+        await resetReplayPerformanceCapture(page);
+        const measurementStarted = await rpc(page, "threadedStartLoop", {
+          clientFps: replayPerformanceMeasuredClientFps,
+          logicFps: replayPerformanceMeasuredLogicFps,
+          catchup: replayPerformanceMeasuredCatchup,
+          profilingEnabled: profileReplayPerformance,
+        });
+        expect(measurementStarted?.ok === true,
+          "performance replay measurement loop did not start",
+          measurementStarted);
+        renderWarmup.measurementStartFrame = replayPerformanceMeasureStartFrame;
+        renderWarmup.renderedWarmupStopped = renderWarmupStopped;
+      }
+    }
     if (replayPerformanceGpuProfileStartFrame > 0
         && replayPerformanceGpuProfileStartFrame < completionThreshold) {
       const requestedStartFrame = replayPerformanceGpuProfileStartFrame;
@@ -1976,9 +2089,13 @@ async function driveReplayPerformance(page, performanceReplay) {
     clientFps: replayPerformanceClientFps,
     logicFps: replayPerformanceLogicFps,
     catchup: replayPerformanceCatchup,
+    measuredClientFps: replayPerformanceMeasuredClientFps,
+    measuredLogicFps: replayPerformanceMeasuredLogicFps,
+    measuredCatchup: replayPerformanceMeasuredCatchup,
     targetLogicFrame,
     visualRequired: requireReplayPerformanceVisible,
-    renderDisabled: disableReplayPerformanceRender,
+    renderDisabled,
+    renderWarmup,
     playbackStart: compactGameplay(playback.frame),
     finalGameplay: compactGameplay(finalFrame.frame),
     recorder,
@@ -1996,6 +2113,9 @@ async function driveReplayPerformance(page, performanceReplay) {
     completionThreshold,
     completionError,
     stopResult: stopped,
+    engineFrameProfiling: profileReplayPerformance,
+    performanceCounters: replayPerformanceCounters,
+    gpuTiming: replayPerformanceGpuTiming,
     gpuProfile,
     statusSamples: capture.statuses,
     slowFrameProfiles,
@@ -2863,13 +2983,21 @@ async function main() {
     harnessUrl.searchParams.set("dist", distDir);
     if (process.env.SKIRMISH_START_THREADS === "1") harnessUrl.searchParams.set("threads", "1");
     if (requestedD3D8Batch) harnessUrl.searchParams.set("d3d8Batch", requestedD3D8Batch);
+    if (requestedD3D8FrameQueue) {
+      harnessUrl.searchParams.set("d3d8FrameQueue", requestedD3D8FrameQueue);
+    }
     if (expectReplayPerformance) {
       // Match the shipping play page's low-overhead diagnostics in the engine
       // worker while retaining counters needed to rank replay render pressure.
       // Full diagnostics time dozens of sub-phases per draw and can dominate
       // the workload that this performance gate is meant to measure.
       harnessUrl.searchParams.set("diag", "lite");
-      harnessUrl.searchParams.set("perfCounters", "1");
+      if (replayPerformanceCounters) {
+        harnessUrl.searchParams.set("perfCounters", "1");
+      }
+      if (replayPerformanceGpuTiming) {
+        harnessUrl.searchParams.set("gpuTiming", "1");
+      }
     }
     if (expectLightPulseProbe) {
       // Terrain buffers are created while diagnostics are in lite mode. Keep

--- a/WebAssembly/pages/project-content.json
+++ b/WebAssembly/pages/project-content.json
@@ -155,7 +155,7 @@
       "name": "Graphics, audio, and movies",
       "status": "in_testing",
       "summary": "WebGL2, Web Audio, and browser-side Bink integration carry the original engine's rendering, sound, and movie requests, with continuing fidelity and coverage work.",
-      "reviewedAt": "2026-07-17",
+      "reviewedAt": "2026-07-25",
       "details": [
         "The Direct3D 8-shaped renderer maps the original rendering path to WebGL2. The default enhanced tier translates shipped shader model 1.1 programs to GLSL ES, while a classic tier generates fixed-function-style shaders for comparison and fallback. Terrain, objects, UI, particles, effects, render targets, and common scenes work; fidelity and performance fixes continue.",
         "Engine-driven music, speech, streams, and two-dimensional and three-dimensional samples play through Web Audio. The mixer retains the engine's category and positional intent at the browser boundary.",
@@ -165,6 +165,8 @@
         "WebAssembly/harness/shader_fidelity_probe.mjs",
         "WebAssembly/harness/d3d8_dxt_cpu_fallback_unit.mjs",
         "WebAssembly/harness/d3d8_dxt_cpu_fallback_browser_smoke.mjs",
+        "WebAssembly/harness/d3d8_sm1_transform_switch_smoke.mjs",
+        "WebAssembly/harness/skirmish_start_smoke.mjs",
         "WebAssembly/harness/terrain_culling_orientation_probe.mjs",
         "WebAssembly/harness/real_audio_event_smoke.mjs",
         "WebAssembly/harness/bink_direct_decoder_browser_smoke.mjs"

--- a/WebAssembly/src/wasm_real_engine_init.cpp
+++ b/WebAssembly/src/wasm_real_engine_init.cpp
@@ -4266,6 +4266,7 @@ void append_real_engine_frame_summary_state(std::string &json)
 	if (TheDisplay != NULL) {
 		json += "\"width\":" + std::to_string(TheDisplay->getWidth());
 		json += ",\"height\":" + std::to_string(TheDisplay->getHeight());
+		json += ",\"averageFps\":" + std::to_string(TheDisplay->getAverageFPS());
 		json += ",\"moviePlaying\":";
 		json += TheDisplay->isMoviePlaying() ? "true" : "false";
 		json += ",\"letterBoxed\":";
@@ -4273,9 +4274,13 @@ void append_real_engine_frame_summary_state(std::string &json)
 		json += ",\"letterBoxFading\":";
 		json += TheDisplay->isLetterBoxFading() ? "true" : "false";
 	} else {
-		json += "\"width\":null,\"height\":null,\"moviePlaying\":null,"
+		json += "\"width\":null,\"height\":null,\"averageFps\":null,\"moviePlaying\":null,"
 			"\"letterBoxed\":null,\"letterBoxFading\":null";
 	}
+	json += ",\"dynamicLod\":";
+	json += TheGameLODManager != NULL
+		? std::to_string(static_cast<Int>(TheGameLODManager->getDynamicLODLevel()))
+		: "null";
 	json += "}";
 	append_real_view_state(json);
 	append_real_particle_state(json);
@@ -6526,6 +6531,32 @@ static const char *run_real_engine_frame_paced(int run_logic, bool render_frame)
 	json += (TheGameLogic != NULL && TheGameLogic->isLoadSessionActive()) ? "true" : "false";
 	json += ",\"loadProgress\":" + std::to_string(
 		TheGameLogic != NULL ? (long long)TheGameLogic->getLoadSessionProgress() : -1);
+	json += ",\"display\":{";
+	if (TheDisplay != NULL) {
+		json += "\"averageFps\":" + std::to_string(TheDisplay->getAverageFPS());
+	} else {
+		json += "\"averageFps\":null";
+	}
+	json += ",\"dynamicLod\":";
+	json += TheGameLODManager != NULL
+		? std::to_string(static_cast<Int>(TheGameLODManager->getDynamicLODLevel()))
+		: "null";
+	json += "}";
+	json += ",\"particles\":{";
+	if (TheParticleSystemManager != NULL) {
+		json += "\"systemCount\":" +
+			std::to_string(TheParticleSystemManager->getParticleSystemCount());
+		json += ",\"particleCount\":" +
+			std::to_string(TheParticleSystemManager->getParticleCount());
+		json += ",\"fieldParticleCount\":" +
+			std::to_string(TheParticleSystemManager->getFieldParticleCount());
+		json += ",\"onScreenParticleCount\":" +
+			std::to_string(TheParticleSystemManager->getOnScreenParticleCount());
+	} else {
+		json += "\"systemCount\":0,\"particleCount\":0,\"fieldParticleCount\":0,"
+			"\"onScreenParticleCount\":0";
+	}
+	json += "}";
 	const bool world_scene_active = TheGameLogic != NULL && TheGameLogic->isInGame()
 		&& !TheGameLogic->isLoadingMap() && !TheGameLogic->isLoadingSave()
 		&& !TheGameLogic->isClearingGameData();


### PR DESCRIPTION
Fixes #323.

The supplied ShockWave 8-AI replay regressed to about 48 FPS during the measured battle window even though the RTX 4080 had GPU time available. Deferred D3D8 frame submission copied dynamic ring-buffer geometry at draw capture and copied it again into upload arenas, moving about 2.2 GB through transient copies. Eager one-observation multi-world CPU baking added another avoidable hot path.

This keeps immutable references to dynamic source ranges until frame-arena materialization, flushes before `DISCARD` or overlapping updates, reuses matrix, viewport, texture, and arena staging storage, and waits for eight repeat observations before promoting multi-world geometry. Added pixel coverage proves overlapping `DISCARD` data is preserved and non-overlapping `NOOVERWRITE` ranges remain in one deferred segment. The replay harness now supports render-gated warm-up, shipping-mode timing, and display/particle telemetry.

## Verification

- Clean RTX 4080 baseline: presentation p50 20.89 ms / p95 31.90 ms; engine p50 18.3 ms / p95 25.4 ms.
- Clean fixed build: presentation p50 16.67 ms / p95 20.73 ms; engine p50 13.5 ms / p95 18.8 ms; rolling engine average 60.63 FPS; no replay CRC mismatch or WebGL context loss; 1 to 585 particles on screen.
- Final staging build remained deterministic at 60.16 FPS with 367 on-screen particles and intact rendered smoke/scene/UI. Its tail timing is not claimed as clean because the shared host's unrelated media job entered the GPU during the sample.
- `npm run test:harness`
- `npm run test:d3d8-buffer-streaming`
- `npm run test:d3d8-sm1-transform-switch-browser`
- `npm run build:port`
- `npm run build:port:threaded:release`
- `npm run test:public-project-content`
- `node --check harness/skirmish_start_smoke.mjs`
- `git diff --check`

Agent-Codename: RedCatVH20
Agent-Model: OpenAI gpt-5.6-sol